### PR TITLE
Convert speedup

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -600,7 +600,7 @@ class unyt_array(np.ndarray):
         units = _sanitize_units_convert(units, self.units.registry)
         if equivalence is None:
             try:
-                conv_data = _check_em_conversion(self.units, units)
+                conv_data = _check_em_conversion(self.units.expr, units.expr)
             except MKSCGSConversionError:
                 raise UnitConversionError(self.units, self.units.dimensions,
                                           units, units.dimensions)
@@ -762,7 +762,7 @@ class unyt_array(np.ndarray):
         units = _sanitize_units_convert(units, self.units.registry)
         if equivalence is None:
             try:
-                conv_data = _check_em_conversion(self.units, units)
+                conv_data = _check_em_conversion(self.units.expr, units.expr)
             except MKSCGSConversionError:
                 raise UnitConversionError(self.units, self.units.dimensions,
                                           units, units.dimensions)
@@ -891,7 +891,7 @@ class unyt_array(np.ndarray):
         2.5e-07 W
         """
         try:
-            conv_data = _check_em_conversion(self.units)
+            conv_data = _check_em_conversion(self.units.expr)
         except MKSCGSConversionError:
             raise UnitsNotReducible(self.units, unit_system)
         if any(conv_data):

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -14,6 +14,10 @@ A class that represents a unit symbol.
 
 
 import copy
+try:
+    from functools import lru_cache
+except ImportError:
+    from backports.functools_lru_cache import lru_cache
 from keyword import iskeyword as _iskeyword
 import numpy as np
 from numbers import Number as numeric_type
@@ -765,6 +769,7 @@ def _get_em_base_unit(units):
     return base_unit
 
 
+@lru_cache(maxsize=128, typed=False)
 def _check_em_conversion(unit_expr, to_unit_expr=None):
     """Check to see if the units contain E&M units
 

--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -33,6 +33,7 @@ class UnitRegistry:
     _unit_system_id = None
 
     def __init__(self, add_default_symbols=True, lut=None):
+        self._unit_object_cache = {}
         if lut:
             self.lut = lut
         else:


### PR DESCRIPTION
This fixes some performance regressions due to recent code churn. I've restored what we used to call `UnitRegistry.unit_objs`. It's now called `UnitRegistry._unit_object_cache`. This makes it clearer that it's a private implementation detail and that it's a cache.

I've additionally made `_check_em_conversion` a pure function that accepts sympy expressions and returns a tuple containing a string and a float. This allows me to decorate it with lru_cache, which saves additional time when converting units.