### PR TITLE
remove setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,6 @@ requirements = [
     'backports.functools_lru_cache;python_version<"3.3"'
 ]
 
-setup_requirements = [
-    'pytest-runner',
-]
-
 test_requirements = [
     'pytest',
 ]
@@ -50,7 +46,6 @@ setup(
     keywords='unyt',
     name='unyt',
     packages=find_packages(include=['unyt']),
-    setup_requires=setup_requirements,
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/yt-project/unyt',


### PR DESCRIPTION
This line in our setup.py causes issues on conda-forge. Let's remove it since I don't think we need it and setup_requires is a footgun because it uses setuptools to install stuff.