### PR TITLE
 implement __round__ for unyt_quantity

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,12 @@ unyt began life as a submodule of yt named yt.units.
 
 It was separated from yt.units as its own package in 2018.
 
+1.0.4 (2018-08-08)
+------------------
+
+* Expand installation instructions
+* Mention paper and arxiv submission in the readme.
+
 1.0.3 (2018-06-06)
 ------------------
 

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1843,6 +1843,9 @@ class unyt_quantity(unyt_array):
             raise RuntimeError("unyt_quantity instances must be scalars")
         return ret
 
+    def __round__(self):
+        return type(self)(round(float(self)), self.units)
+
 
 def _validate_numpy_wrapper_units(v, arrs):
     if not any(isinstance(a, unyt_array) for a in arrs):

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -1902,3 +1902,15 @@ def test_creation():
         unyt_quantity('hello', 'cm')
     with pytest.raises(RuntimeError):
         unyt_quantity(np.array([1, 2, 3]), 'cm')
+
+
+def test_round():
+    from unyt import km
+
+    assert_equal(round(3.3*km), 3.)
+    assert_equal(round(3.5*km), 4.)
+    assert_equal(round(3*km), 3)
+    assert_equal(round(3.7*km), 4)
+
+    with pytest.raises(TypeError):
+        round([1, 2, 3]*km)


### PR DESCRIPTION
`round` *should* raise an error for `unyt_array` but there's no reason not to define it for scalars, so I've added an implementation of `__round__` to `unyt_quantity`.

Also missed a changelog update for the minor release I did to include the arxiv submission in the pypi readme.