### PR TITLE
Allow taking scalars to dimensionless array powers

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1577,16 +1577,17 @@ class unyt_array(np.ndarray):
                 u1 = Unit(registry=getattr(u0, 'registry', None))
             elif ufunc is power:
                 u1 = inp1
-                if isinstance(u1, np.ndarray):
-                    if isinstance(u1, unyt_array):
-                        if u1.units.is_dimensionless:
-                            pass
-                        else:
-                            raise UnitOperationError(ufunc, u0, u1)
-                    try:
-                        u1 = float(u1)
-                    except TypeError:
+                if inp0.shape != () and inp1.shape != ():
+                    raise UnitOperationError(ufunc, u0, u1)
+                if isinstance(u1, unyt_array):
+                    if u1.units.is_dimensionless:
+                        pass
+                    else:
                         raise UnitOperationError(ufunc, u0, u1)
+                if u1.shape == ():
+                    u1 = float(u1)
+                else:
+                    u1 = 1.0
             unit_operator = self._ufunc_registry[ufunc]
             if unit_operator in (_preserve_units, _comparison_unit,
                                  _arctan2_unit):

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -928,7 +928,7 @@ def unary_ufunc_comparison(ufunc, a):
 
 
 def binary_ufunc_comparison(ufunc, a, b):
-    out = a.copy()
+    out = b.copy()
     if ufunc in yield_np_ufuncs([
             'add', 'subtract', 'remainder', 'fmod', 'mod', 'arctan2', 'hypot',
             'greater', 'greater_equal', 'less', 'less_equal', 'equal',
@@ -986,6 +986,7 @@ def test_ufuncs():
                 ufunc(a, c)
             with pytest.raises(UnitOperationError):
                 ufunc(a, d)
+            binary_ufunc_comparison(ufunc, np.array(2.0), b)
             continue
 
         a = unyt_array([.3, .4, .5], 'cm')


### PR DESCRIPTION
This allows one to do something like:

```
data = unyt_array([1, 2, 3], '')
3**data
```

This is a well-defined operation that we weren't allowing before. With this PR it's once again legal to do this.

This came up in the context of porting yt to use unyt under the hood.