### PR TITLE
fix pypi upload step on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,4 +58,4 @@ deploy:
   on:
     tags: true
     repo: yt-project/unyt
-    python: 3.6
+    os: linux


### PR DESCRIPTION
The last PR accidentally broke the pypi upload on tag functionality I added a while ago. I'm pretty sure this will fix it.