### PR TITLE
paper over python2 test failure

### DIFF
--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -719,7 +719,7 @@ def test_temperature_conversions():
         balmy_F/balmy_F
     with pytest.raises(InvalidUnitOperation):
         balmy_F/balmy_C
-    assert_equal(np.add(balmy_F, balmy_F), unyt_quantity(80.33*2, 'degF'))
+    assert np.add(balmy_F, balmy_F) == unyt_quantity(80.33*2, 'degF')
     with pytest.raises(InvalidUnitOperation):
         np.add(balmy_F, balmy_C)
     with pytest.raises(InvalidUnitOperation):


### PR DESCRIPTION
It looks like numpy 1.15.0 caused some breakage on python2.7. It has something to do with array scalars not behaving correctly (the backtrace comes from a usage of `assert_equal`). I don't really want to dig and figure out exactly what changed, so I'm just papering it over here by dropping the problematic call to `assert_equal`.