### PR TITLE
Unyt.test

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,3 +10,4 @@ recursive-exclude * *.py[co]
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
 include versioneer.py
 include unyt/_version.py
+recursive-include unyt/tests/ *.py

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ The ``unyt`` package (pronounced like "unit") provides a subclass of NumPy's
     [ 5.4717696  9.3341952 11.5872768] km
 
 And a whole lot more! See `the documentation <http://unyt.readthedocs.io>`_ for
-more examples as well as full API docs.
+installation instructions, more examples, and full API reference.
 
 This package only depends on ``numpy``, ``sympy``, ``six`` and, on Python 2.7,
 ``backports.functools_lru_cache`` (a backport of ``functools.lru_cache``).

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,7 +8,7 @@ Installation
 Stable release
 --------------
 
-To install unyt, run this command in your terminal:
+To install :mod:`unyt`, run this command in your terminal:
 
 .. code-block:: console
 
@@ -20,7 +20,7 @@ which will improve the performance of `SymPy`_.
 If you don't have `pip`_ installed, this `Python installation guide`_ can guide
 you through the process.
 
-If you use `conda`_, ``unyt`` is available via `conda-forge`_:
+If you use `conda`_, :mod:`unyt` is available via `conda-forge`_:
 
 .. code-block:: console
 
@@ -39,7 +39,7 @@ because it will be installed automatically as a dependency of ``SymPy``.
 From source
 -----------
 
-The sources for unyt can be downloaded from the `Github repo`_.
+The sources for :mod:`unyt` can be downloaded from the `Github repo`_.
 
 You can either clone the public repository:
 
@@ -68,3 +68,14 @@ Python source files of the installed version of ``unyt``, then you can do:
 
 .. _Github repo: https://github.com/yt-project/unyt
 .. _tarball: https://github.com/yt-project/unyt/tarball/master
+
+Running the tests
+-----------------
+
+You can check that :mod:`unyt` is working properly by running the unit tests
+on your intalled copy:
+
+.. doctest::
+
+  >>> import unyt
+  >>> unyt.test()  # doctest: +SKIP

--- a/unyt/__init__.py
+++ b/unyt/__init__.py
@@ -13,6 +13,7 @@ top-level ``unyt`` namespace:
 
 * :func:`unyt.array.loadtxt`
 * :func:`unyt.array.savetxt`
+* :func:`unyt.test`
 * :func:`unyt.array.uconcatenate`
 * :func:`unyt.array.ucross`
 * :func:`unyt.array.udot`
@@ -108,3 +109,14 @@ del import_quantities
 
 __version__ = get_versions()['version']
 del get_versions
+
+
+def test():  # pragma: no cover
+    """Execute the unit tests on an installed copy of unyt.
+
+    Note that this function requires pytest to run. If pytest is not
+    installed this function will raise ImportError.
+    """
+    import pytest
+    import os
+    pytest.main([os.path.dirname(os.path.abspath(__file__))])


### PR DESCRIPTION
As requested by @ygrange in https://github.com/openjournals/joss-reviews/issues/809 I've added the ability to run the tests on an installed copy of unyt. I've verified that this function doesn't get executed by the main test suite as a test itself (causing the tests to recursively call themselves) and I've also made it so the usage example I've added gets excluded from the doctests and coverage estimates.