### PR TITLE
Add documentation on running the tests

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -134,7 +134,8 @@ Before you submit a pull request, check that it meets these guidelines:
 
 1. The pull request should include tests for functionality that is not already
    tested. We strive for 100% test coverage and pull requests should not add any
-   new untested code. Use the codecov.io reports on the pull request to gaugue
+   new untested code. Use the `codecov.io reports
+   <https://codecov.io/gh/yt-project/unyt>`_ on the pull request to gauge
    coverage. You can also generate coverage reports locally by running the
    ``tox`` tests.
 2. If the pull request adds functionality the docs should be updated. If your

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -132,12 +132,17 @@ Pull Request Guidelines
 
 Before you submit a pull request, check that it meets these guidelines:
 
-1. The pull request should include tests functionality that is not already
+1. The pull request should include tests for functionality that is not already
    tested. We strive for 100% test coverage and pull requests should not add any
-   new untested code.
-2. If the pull request adds functionality, the docs should be updated. Put
-   your new functionality into a function with a docstring, and add the
-   feature to the list in README.rst.
+   new untested code. Use the codecov.io reports on the pull request to gaugue
+   coverage. You can also generate coverage reports locally by running the
+   ``tox`` tests.
+2. If the pull request adds functionality the docs should be updated. If your
+   new functionality adds new functions or classes to the public API, please add
+   docstrings. If you modified an existing function or class in the public API,
+   please update the existing docstrings. If you modify private implementation
+   details, please use your judgment on documenting it with comments or
+   docstrings.
 3. The pull request should work for Python 2.7, 3.4, 3.5, 3.6, and 3.7. Check
    https://travis-ci.org/yt-project/unyt/pull_requests
    and make sure that the tests pass for all supported Python versions.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -116,16 +116,16 @@ We use the ``pytest`` test runner as well as the ``tox`` test wrapper to manage 
 the ``unyt`` repository, simply run ``pytest`` in the root of the repository::
 
    $ cd unyt/
-   $ py.test
+   $ py.test --doctest-modules --doctest-glob='*.rst' --doctest-plus
 
-Some tests depend on ``h5py``, ``Pint``, ``astropy``, and ``flake8`` being installed.
+You will need to install ``pytest`` and ``pytest-doctestplus`` from ``pip`` to run this command. Some tests depend on ``h5py``, ``Pint``, ``astropy``, and ``flake8`` being installed.
 
 If you would like to run the tests on multiple python versions, first ensure that you have multiple python versions visible on your ``$PATH``, then simply execute ``tox`` in the root of the ``unyt`` repository::
 
    $ cd unyt
    $ tox
 
-The ``tox`` package itself can be installed using the ``pip`` associated with one of the python installations. See the ``tox.ini`` file in the root of the repository for more details about our ``tox`` setup.
+The ``tox`` package itself can be installed using the ``pip`` associated with one of the python installations. See the ``tox.ini`` file in the root of the repository for more details about our ``tox`` setup. Note that you do not need to install anything besides ``tox`` and ``python`` for this to work, ``tox`` will handle setting up the test environment, including installing any necessary dependencies via ``pip``.
 
 Pull Request Guidelines
 -----------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -109,16 +109,36 @@ Ready to contribute? Here's how to set up ``unyt`` for local development.
 
 7. Submit a pull request through the GitHub website.
 
+Testing unyt
+------------
+
+We use the ``pytest`` test runner as well as the ``tox`` test wrapper to manage running tests on various versions of python. To run the tests on your copy of
+the ``unyt`` repository, simply run ``pytest`` in the root of the repository::
+
+   $ cd unyt/
+   $ py.test
+
+Some tests depend on ``h5py``, ``Pint``, ``astropy``, and ``flake8`` being installed.
+
+If you would like to run the tests on multiple python versions, first ensure that you have multiple python versions visible on your ``$PATH``, then simply execute ``tox`` in the root of the ``unyt`` repository::
+
+   $ cd unyt
+   $ tox
+
+The ``tox`` package itself can be installed using the ``pip`` associated with one of the python installations. See the ``tox.ini`` file in the root of the repository for more details about our ``tox`` setup.
+
 Pull Request Guidelines
 -----------------------
 
 Before you submit a pull request, check that it meets these guidelines:
 
-1. The pull request should include tests.
+1. The pull request should include tests functionality that is not already
+   tested. We strive for 100% test coverage and pull requests should not add any
+   new untested code.
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6. Check
+3. The pull request should work for Python 2.7, 3.4, 3.5, 3.6, and 3.7. Check
    https://travis-ci.org/yt-project/unyt/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
@@ -129,7 +149,7 @@ A reminder for the maintainers on how to deploy.
 Make sure all your changes are committed (including an entry in HISTORY.rst).
 Then run::
 
-$ git tag v1.x.x
-$ git push upstream master --tags
+  $ git tag v1.x.x
+  $ git push upstream master --tags
 
 Travis will then deploy to PyPI if tests pass.


### PR DESCRIPTION
This responds to @ygrange's comment here: https://github.com/openjournals/joss-reviews/issues/809#issuecomment-406381056

I've added a section to the developer docs on running the tests locally using either `py.test` or `tox`. I've also mentioned the extra test dependencies. I also expanded a little bit on the pull request guidelines to reflect what I actually think about merging PRs to this repo. @jzuhone might want to give this a quick lookover.