### PR TITLE
add unyt_array.argsort. Fixes #51

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,6 @@ environment:
     - TOXENV: py27
     - TOXENV: py37
 
-platform: x64
-
 matrix:
   fast_finish: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,8 @@ environment:
     - TOXENV: py27
     - TOXENV: py37
 
+platform: x64
+
 matrix:
   fast_finish: true
 

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1099,6 +1099,24 @@ class unyt_array(np.ndarray):
         """
         return np.array(self)
 
+    def argsort(self, axis=-1, kind='quicksort', order=None):
+        """
+        Returns the indices that would sort the array.
+
+        See the documentation of ndarray.argsort for details about the keyword
+        arguments.
+
+        Example
+        -------
+        >>> from unyt import km
+        >>> data = [3, 8, 7]*km
+        >>> np.argsort(data)
+        array([0, 2, 1])
+        >>> data.argsort()
+        array([0, 2, 1])
+        """
+        return self.view(np.ndarray).argsort(axis, kind, order)
+
     @classmethod
     def from_astropy(cls, arr, unit_registry=None):
         """

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1110,10 +1110,10 @@ class unyt_array(np.ndarray):
         -------
         >>> from unyt import km
         >>> data = [3, 8, 7]*km
-        >>> np.argsort(data)
-        array([0, 2, 1])
-        >>> data.argsort()
-        array([0, 2, 1])
+        >>> print(np.argsort(data))
+        [0 2 1]
+        >>> print(data.argsort())
+        [0 2 1]
         """
         return self.view(np.ndarray).argsort(axis, kind, order)
 


### PR DESCRIPTION
There's a doctest in the docstring that should suffice as a test. Let's see what the coverage report says. ping @brittonsmith 

It turns out numpy has an internal hook to call obj.argsort if it's defined for an object passed to `np.argsort`. Not sure why this behaves differently in yt.units, in principle this could be backported there.