### PR TITLE
Support integer and reduced precision arrays. Fixes #55

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -63,7 +63,7 @@ in the example::
 
   >>> semimajor_axis = [421700, 671034, 1070412, 1882709]*km
   >>> semimajor_axis
-  unyt_array([ 421700.,  671034., 1070412., 1882709.], 'km')
+  unyt_array([ 421700,  671034, 1070412, 1882709], 'km')
 
 By multiplying by ``km``, we converted the python list into a
 :class:`unyt.unyt_array <unyt.array.unyt_array>` instance. This is a class
@@ -71,7 +71,7 @@ that's built into :mod:`unyt`, has units attached to it, and knows how to
 convert itself into different dimensionally equivalent units::
 
   >>> semimajor_axis.value
-  array([ 421700.,  671034., 1070412., 1882709.])
+  array([ 421700,  671034, 1070412, 1882709])
   >>> semimajor_axis.units
   km
   >>> print(semimajor_axis.to('AU'))
@@ -135,7 +135,7 @@ Similarly one can multiply two units together to create new compound units::
   >>> from unyt import N, m
   >>> energy = 3*N * 4*m
   >>> print(energy)
-  12.0 N*m
+  12 N*m
   >>> print(energy.to('erg'))
   120000000.0 erg
 
@@ -189,7 +189,7 @@ the :class:`unyt.unyt_array <unyt.array.unyt_array>` class to quickly apply unit
   unyt_arrays with units "cm/s" (dimensions "(length)/(time)") and
   "dimensionless" (dimensions "1") is not well defined.
   >>> velocities + 12*velocities.units
-  unyt_array([22., 32., 42.], 'cm/s')
+  unyt_array([22, 32, 42], 'cm/s')
 
 Logarithms, Exponentials, and Trigonometric Functions
 -----------------------------------------------------
@@ -280,7 +280,7 @@ accomplished with the :meth:`unyt_array.convert_to_units
   >>> from unyt import mile
   >>> data = [1, 2, 3]*mile
   >>> data
-  unyt_array([1., 2., 3.], 'mile')
+  unyt_array([1, 2, 3], 'mile')
   >>> data.convert_to_units('km')
   >>> data
   unyt_array([1.609344, 3.218688, 4.828032], 'km')
@@ -386,7 +386,7 @@ methods:
   unyt_quantity(4.78843804, 'Msun/kpc**2')
   >>> data = [100, 500, 700]*horsepower
   >>> data
-  unyt_array([100., 500., 700.], 'hp')
+  unyt_array([100, 500, 700], 'hp')
   >>> data.convert_to_base('mks')
   >>> data
   unyt_array([ 74569.98715823, 372849.93579114, 521989.91010759], 'W')
@@ -544,26 +544,26 @@ To obtain a new array containing a copy of the original data, use either the
   >>> import numpy as np
   >>> data = [1, 2, 3]*g
   >>> data
-  unyt_array([1., 2., 3.], 'g')
+  unyt_array([1, 2, 3], 'g')
   >>> np.array(data)
-  array([1., 2., 3.])
+  array([1, 2, 3])
   >>> data.to_value('kg')
   array([0.001, 0.002, 0.003])
   >>> data.value
-  array([1., 2., 3.])
+  array([1, 2, 3])
   >>> data.v
-  array([1., 2., 3.])
+  array([1, 2, 3])
 
 Similarly, to obtain a ndarray containing a view of the data in the original
 array, use either the :attr:`unyt_array.ndview <unyt.array.unyt_array.ndview>`
 or the :attr:`unyt_array.d <unyt.array.unyt_array.d>` properties:
 
   >>> data.view(np.ndarray)
-  array([1., 2., 3.])
+  array([1, 2, 3])
   >>> data.ndview
-  array([1., 2., 3.])
+  array([1, 2, 3])
   >>> data.d
-  array([1., 2., 3.])
+  array([1, 2, 3])
 
 Applying units to data
 ----------------------
@@ -597,7 +597,7 @@ with the same units:
 
   >>> more_data = [4, 5, 6]*data_with_units.units
   >>> more_data
-  unyt_array([4., 5., 6.], 'g')
+  unyt_array([4, 5, 6], 'g')
 
 Working with code that uses ``astropy.units``
 ---------------------------------------------
@@ -643,7 +643,7 @@ instances. To convert data from ``Pint`` to :mod:`unyt`, use the :func:`unyt_arr
   <Quantity([0 1 2 3], 'erg / centimeter ** 3')>
   >>> c = unyt_array.from_pint(b)
   >>> c
-  unyt_array([0., 1., 2., 3.], 'erg/cm**3')
+  unyt_array([0, 1, 2, 3], 'erg/cm**3')
 
 And to convert data contained in a :class:`unyt_array <unyt.array.unyt_array>`
 instance, use the :meth:`unyt_array.to_pint <unyt.array.unyt_array.to_pint>`
@@ -652,12 +652,12 @@ method:
   >>> from unyt import cm, s
   >>> a = 4*cm**2/s
   >>> print(a)
-  4.0 cm**2/s
+  4 cm**2/s
   >>> a.to_pint()
-  <Quantity(4.0, 'centimeter ** 2 / second')>
+  <Quantity(4, 'centimeter ** 2 / second')>
   >>> b = [1, 2, 3]*cm
   >>> b.to_pint()
-  <Quantity([1. 2. 3.], 'centimeter')>
+  <Quantity([1 2 3], 'centimeter')>
 
 
 Integrating :mod:`unyt` Into a Python Library
@@ -738,33 +738,73 @@ Sometimes it is convenient to create a unit registry containing new units that a
   >>> u = Unit('code_length', registry=reg)
   >>> data = 3*u
   >>> print(data)
-  3.0 code_length
+  3 code_length
 
 As you can see, you can test whether a unit name is in a registry using the
 Python ``in`` operator.
 
 In an application that depends on ``unyt``, it is often convenient to define
-methods or functions to automatically attach the correct unit registry to a set
-unit object. For example, consider a ``Simulation`` class. Let's give this class
-two methods named ``quantitity`` and ``array`` to create new :mod:`unyt_array
-<unyt.array.unyt_array>` and :mod:`unyt_quantity <unyt.array.unyt_quantity>`
-instances, respectively:
+methods or functions to automatically attach the correct unit registry to unit
+objects associated with an object. For example, consider a ``Simulation``
+class. Let's give this class two methods named ``array`` and ``quantity`` to
+create new :mod:`unyt_array <unyt.array.unyt_array>` and :mod:`unyt_quantity
+<unyt.array.unyt_quantity>` instances, respectively:
 
   >>> class Simulation(object):
   ...     def __init__(self, registry):
   ...         self.registry = registry
   ...
-  ...     def quan(self, value, units):
-  ...         return unyt_quantity(value, units, registry=self.registry)
-  ...
   ...     def array(self, value, units):
   ...         return unyt_array(value, units, registry=self.registry)
   ...
-  >>> s = Simulation(reg)
+  ...     def quantity(self, value, units):
+  ...         return unyt_quantity(value, units, registry=self.registry)
+  ...
+  >>> registry = UnitRegistry()
+  >>> registry.add("code_length", base_value=3.2, dimensions=length)
+  >>> s = Simulation(registry)
   >>> s.array([1, 2, 3], 'code_length')
-  unyt_array([1., 2., 3.], 'code_length')
+  unyt_array([1, 2, 3], 'code_length')
 
-As for arrays with different units, for operation between two arrays with units that have references to different unit registries, the result of the operation will have the same unit registry as the leftmost unit. This can sometimes lead to surprising behaviors where data will seem to "forget" about custom units. In this situation it is important to make sure ahead of time that all data are created with units using the same unit registry. If for some reason that is not possible (for example, when comparing data from two different simulations with different internal units), then care must be taken when working with custom units. To avoid these sorts of ambiguities it is best to do work in physical units as much as possible.
+We can create an array with ``"code_length"`` here because ``s.registry``, the ``UnitRegistry`` instance associated with our Simulation instance has a ``"code_length"`` unit defined.
+
+As for arrays with different units, for operations between arrays created with
+different unit registries, the result of the operation will use the same unit
+registry as the leftmost unit. This can sometimes lead to surprising behaviors
+where data will seem to "forget" about custom units. In this situation it is
+important to make sure ahead of time that all data are created with units using
+the same unit registry. If for some reason that is not possible (for example,
+when comparing data from two different simulations with different internal
+units), then care must be taken when working with custom units. To avoid these
+sorts of ambiguities it is best to do work in physical units as much as
+possible.
+
+Dealing with data types
+-----------------------
+
+The :mod:`unyt` library supports creating :class:`unyt.unyt_array <unyt.array.unyt_array>` and :class:`unyt.unyt_quantity <unyt.array.unyt_quantity>` instances with arbitrary integer or floating point data types:
+
+   >>> import numpy as np
+   >>> from unyt import km
+   ...
+   >>> int_data = [1, 2, 3]*km
+   >>> int_data
+   unyt_array([1, 2, 3], 'km')
+   >>> data.dtype
+   dtype('int64')
+   >>> float32_data = np.array([1, 2, 3], dtype='float32')*km
+   >>> float32_data
+   unyt_array([1., 2., 3.], dtype=float32, units='km')
+
+The ``dtype`` of a ``unyt_array`` instance created by multiplying an iterable by
+a unit will be the same as passing the iterable to ``np.array()``. You can also
+manually specify the ``dtype`` by calling ``np.array()`` yourself or by using
+the ``unyt_array`` initializer directly:
+
+   >>> np.array([1, 2, 3], dtype='float64')*km
+   unyt_array([1., 2., 3.], 'km')
+   >>> unyt_array([1, 2, 3], 'km', dtype='int32')
+   unyt_array([1, 2, 3], dtype=int32, units='km')
 
 Writing Data with Units to Disk
 -------------------------------
@@ -789,7 +829,7 @@ this example:
   >>> np.save('my_data_cm.npy', data)
   >>> new_data = np.load('my_data_cm.npy')
   >>> new_data
-  array([1., 2., 3.])
+  array([1, 2, 3])
   >>> new_data_with_units = new_data * cm
   >>> os.remove('my_data_cm.npy')
 
@@ -812,7 +852,7 @@ Of course in this example using ``numpy.save`` we need to hard-code the units be
   >>> unit = Unit(unit_str)
   >>> new_data = new_data*unit
   >>> new_data
-  unyt_array([1., 2., 3.], 'cm')
+  unyt_array([1, 2, 3], 'cm')
   >>> os.remove('my_data.h5')
 
 HDF5 Files
@@ -826,7 +866,7 @@ The :mod:`unyt` library provides a hook for writing data both to a new HDF5 file
   >>> data.write_hdf5('my_data.h5')
   ...
   >>> unyt_array.from_hdf5('my_data.h5')
-  unyt_array([1., 2., 3.], 'cm')
+  unyt_array([1, 2, 3], 'cm')
   >>> os.remove('my_data.h5')
 
 By default the data will be written to the root group of the HDF5 file in a dataset named ``'array_data'``. You can also specify that you would like
@@ -836,7 +876,7 @@ the data to be saved in a particular group or dataset in the file:
   ...                 group_name='my_special_group')
   >>> unyt_array.from_hdf5('my_data.h5', dataset_name='my_special_data',
   ...                      group_name='my_special_group')
-  unyt_array([1., 2., 3.], 'cm')
+  unyt_array([1, 2, 3], 'cm')
   >>> os.remove('my_data.h5')
 
 You can even write to files and groups that already exist:
@@ -848,7 +888,7 @@ You can even write to files and groups that already exist:
   ...
   >>> with h5py.File('my_data.h5') as f:
   ...     print(f['my_custom_group/array_data'][:])
-  [1. 2. 3.]
+  [1 2 3]
   >>> os.remove('my_data.h5')
 
 If the dataset that you would like to write to already exists, :mod:`unyt`
@@ -871,7 +911,7 @@ restoring the data from disk. Here is a short example illustrating this:
   >>> data.write_hdf5('my_code_data.h5')
   >>> read_data = data.from_hdf5('my_code_data.h5')
   >>> read_data
-  unyt_array([1., 2., 3.], 'cm')
+  unyt_array([1, 2, 3], 'cm')
   >>> read_data.to('code_length')
   unyt_array([0.001, 0.002, 0.003], 'code_length')
   >>> os.remove('my_code_data.h5')

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -36,11 +36,11 @@ into :mod:`unyt`) and the semimajor axis of the orbits of Jupiter's moons, which
 we can look up from `Wikipedia
 <https://en.wikipedia.org/wiki/Moons_of_Jupiter#List>`_ and enter by hand::
 
-  >>> from unyt import Mjup, G, km
+  >>> from unyt import Mjup, G, AU
   >>> from math import pi
   ...
   >>> moons = ['Io', 'Europa', 'Ganymede', 'Callisto']
-  >>> semimajor_axis = [421700, 671034, 1070412, 1882709]*km
+  >>> semimajor_axis = [.002819, .0044856, .00715526, .01258513]*AU
   ...
   >>> period = 2*pi*(semimajor_axis**3/(G*Mjup))**0.5
   >>> period = period.to('d')
@@ -61,9 +61,9 @@ The :mod:`unyt` namespace has a large number of units and physical constants you
 can import to apply units to data in your own code. You can see how that works
 in the example::
 
-  >>> semimajor_axis = [421700, 671034, 1070412, 1882709]*km
+  >>> semimajor_axis = [.002819, .0044856, .00715526, .01258513]*AU
   >>> semimajor_axis
-  unyt_array([ 421700,  671034, 1070412, 1882709], 'km')
+  unyt_array([0.002819  , 0.0044856 , 0.00715526, 0.01258513], 'AU')
 
 By multiplying by ``km``, we converted the python list into a
 :class:`unyt.unyt_array <unyt.array.unyt_array>` instance. This is a class
@@ -71,11 +71,11 @@ that's built into :mod:`unyt`, has units attached to it, and knows how to
 convert itself into different dimensionally equivalent units::
 
   >>> semimajor_axis.value
-  array([ 421700,  671034, 1070412, 1882709])
+  array([0.002819  , 0.0044856 , 0.00715526, 0.01258513])
   >>> semimajor_axis.units
-  km
-  >>> print(semimajor_axis.to('AU'))
-  [0.00281889 0.00448559 0.00715526 0.01258513] AU
+  AU
+  >>> print(semimajor_axis.to('km'))
+  [ 421716.39764641  671036.20903964 1070411.66066813 1882708.6511216 ] km
 
 Next, we calculated the orbital period by translating the orbital period
 formula to Python and then converting the answer to the units we want in the
@@ -83,9 +83,10 @@ end, days::
 
   >>> period = 2*pi*(semimajor_axis**3/(G*Mjup))**0.5
   >>> period
-  unyt_array([ 4.83380797,  9.70288268, 19.54836529, 45.5993645 ], 'km**(3/2)*s/m**(3/2)')
+  unyt_array([2.64196224e-12, 5.30291672e-12, 1.06837107e-11,
+              2.49212918e-11], 'AU**(3/2)*s/m**(3/2)')
   >>> period.to('d')
-  unyt_array([ 1.76919479,  3.55129736,  7.1547869 , 16.68956617], 'd')
+  unyt_array([ 1.76929798,  3.55131489,  7.1547835 , 16.68956153], 'd')
 
 Note that we haven't added any conversion factors between different units,
 that's all handled internally by :mod:`unyt`. Also note how the intermediate
@@ -98,7 +99,7 @@ python syntax. This means you must use `**` and not `^`, even when writing a
 unit as a string:
 
   >>> from unyt import kg, m
-  >>> print((10*kg/m**3).to('g/cm**3'))
+  >>> print((10.*kg/m**3).to('g/cm**3'))
   0.01 g/cm**3
 
 Arithmetic and units
@@ -111,7 +112,7 @@ mistake in your units in a mathematical formula. To see what I mean by that,
 let's take a look at the following examples::
 
   >>> from unyt import cm, m, ft, yard
-  >>> print(3*cm + 4*m - 5*ft + 6*yard)
+  >>> print(3.*cm + 4.*m - 5.*ft + 6.*yard)
   799.24 cm
 
 Despite the fact that the four unit symbols used in the above example correspond
@@ -126,7 +127,7 @@ returns data in the units of the leftmost object in an expression::
 One can also form more complex units out of atomic unit symbols. For example, here is how we'd create an array with units of meters per second and print out the values in the array in miles per hour::
 
   >>> from unyt import m, s
-  >>> velocities = [20, 22, 25]*m/s
+  >>> velocities = [20., 22., 25.]*m/s
   >>> print(velocities.to('mile/hr'))
   [44.73872584 49.21259843 55.9234073 ] mile/hr
 
@@ -209,10 +210,10 @@ The one exception to this rule is for trigonometric functions applied to data wi
 
   >>> from unyt import degree, radian
   >>> import numpy as np
-  >>> print(np.sin(np.pi/4*radian))
-  0.7071067811865475
-  >>> print(np.sin(45*degree))
-  0.7071067811865475
+  >>> np.sin(np.pi/4*radian)
+  array(0.70710678)
+  >>> np.sin(45.*degree)
+  array(0.70710678)
 
 Printing Units
 --------------
@@ -278,9 +279,9 @@ accomplished with the :meth:`unyt_array.convert_to_units
 <unyt.array.unyt_array.convert_to_units>` function:
 
   >>> from unyt import mile
-  >>> data = [1, 2, 3]*mile
+  >>> data = [1., 2., 3.]*mile
   >>> data
-  unyt_array([1, 2, 3], 'mile')
+  unyt_array([1., 2., 3.], 'mile')
   >>> data.convert_to_units('km')
   >>> data
   unyt_array([1.609344, 3.218688, 4.828032], 'km')
@@ -384,9 +385,9 @@ methods:
   >>> from unyt import g, cm, horsepower
   >>> (1e-9*g/cm**2).in_base('galactic')
   unyt_quantity(4.78843804, 'Msun/kpc**2')
-  >>> data = [100, 500, 700]*horsepower
+  >>> data = [100., 500., 700.]*horsepower
   >>> data
-  unyt_array([100, 500, 700], 'hp')
+  unyt_array([100., 500., 700.], 'hp')
   >>> data.convert_to_base('mks')
   >>> data
   unyt_array([ 74569.98715823, 372849.93579114, 521989.91010759], 'W')
@@ -542,28 +543,28 @@ To obtain a new array containing a copy of the original data, use either the
 
   >>> from unyt import g
   >>> import numpy as np
-  >>> data = [1, 2, 3]*g
+  >>> data = [1., 2., 3.]*g
   >>> data
-  unyt_array([1, 2, 3], 'g')
+  unyt_array([1., 2., 3.], 'g')
   >>> np.array(data)
-  array([1, 2, 3])
+  array([1., 2., 3.])
   >>> data.to_value('kg')
   array([0.001, 0.002, 0.003])
   >>> data.value
-  array([1, 2, 3])
+  array([1., 2., 3.])
   >>> data.v
-  array([1, 2, 3])
+  array([1., 2., 3.])
 
 Similarly, to obtain a ndarray containing a view of the data in the original
 array, use either the :attr:`unyt_array.ndview <unyt.array.unyt_array.ndview>`
 or the :attr:`unyt_array.d <unyt.array.unyt_array.d>` properties:
 
   >>> data.view(np.ndarray)
-  array([1, 2, 3])
+  array([1., 2., 3.])
   >>> data.ndview
-  array([1, 2, 3])
+  array([1., 2., 3.])
   >>> data.d
-  array([1, 2, 3])
+  array([1., 2., 3.])
 
 Applying units to data
 ----------------------
@@ -793,8 +794,6 @@ data types:
    >>> int_data = [1, 2, 3]*km
    >>> int_data
    unyt_array([1, 2, 3], 'km')
-   >>> data.dtype
-   dtype('int64')
    >>> float32_data = np.array([1, 2, 3], dtype='float32')*km
    >>> float32_data
    unyt_array([1., 2., 3.], dtype=float32, units='km')
@@ -806,24 +805,26 @@ the ``unyt_array`` initializer directly:
 
    >>> np.array([1, 2, 3], dtype='float64')*km
    unyt_array([1., 2., 3.], 'km')
-   >>> unyt_array([1, 2, 3], 'km', dtype='int32')
-   unyt_array([1, 2, 3], dtype=int32, units='km')
 
-Operations that convert an integer array to a new unit will convert the array to the floating point type with an equivalent size. For example, Calling ``in_units`` on a 32 bit integer array with units of kilometers will return a 32 bit floating point array.
+Operations that convert an integer array to a new unit will convert the array to
+the floating point type with an equivalent size. For example, Calling
+``in_units`` on a 32 bit integer array with units of kilometers will return a 32
+bit floating point array.
 
    >>> data = np.array([1, 2, 3], dtype='int32')*km
    >>> data.in_units('mile')
    unyt_array([0.62137121, 1.24274242, 1.86411357], dtype=float32, units='mile')
 
-In-place operations will also mutate the dtype from float to integer in these cases, again in away that will preserve the byte size of the data.
+In-place operations will also mutate the dtype from float to integer in these
+cases, again in away that will preserve the byte size of the data.
 
-   >>> data
-   unyt_array([1, 2, 3], dtype=int32, units='km')
    >>> data.convert_to_units('mile')
    >>> data
    unyt_array([0.62137121, 1.24274242, 1.86411357], dtype=float32, units='mile')
 
-It is possible that arrays containing large integers (16777217 for 32 bit and 9007199254740993 for 64 bit) will lose precision when converting data to a different unit. In these cases a warning message will be printed.
+It is possible that arrays containing large integers (16777217 for 32 bit and
+9007199254740993 for 64 bit) will lose precision when converting data to a
+different unit. In these cases a warning message will be printed.
 
 Writing Data with Units to Disk
 -------------------------------
@@ -926,11 +927,11 @@ restoring the data from disk. Here is a short example illustrating this:
   >>> reg.add("code_length", base_value=10.0, dimensions=length,
   ...         tex_repr=r"\rm{Code Length}")
   >>> u = Unit('cm', registry=reg)
-  >>> data = [1, 2, 3]*u
+  >>> data = [1., 2., 3.]*u
   >>> data.write_hdf5('my_code_data.h5')
   >>> read_data = data.from_hdf5('my_code_data.h5')
   >>> read_data
-  unyt_array([1, 2, 3], 'cm')
+  unyt_array([1., 2., 3.], 'cm')
   >>> read_data.to('code_length')
   unyt_array([0.001, 0.002, 0.003], 'code_length')
   >>> os.remove('my_code_data.h5')

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -782,7 +782,10 @@ possible.
 Dealing with data types
 -----------------------
 
-The :mod:`unyt` library supports creating :class:`unyt.unyt_array <unyt.array.unyt_array>` and :class:`unyt.unyt_quantity <unyt.array.unyt_quantity>` instances with arbitrary integer or floating point data types:
+The :mod:`unyt` library supports creating :class:`unyt.unyt_array
+<unyt.array.unyt_array>` and :class:`unyt.unyt_quantity
+<unyt.array.unyt_quantity>` instances with arbitrary integer or floating point
+data types:
 
    >>> import numpy as np
    >>> from unyt import km
@@ -805,6 +808,22 @@ the ``unyt_array`` initializer directly:
    unyt_array([1., 2., 3.], 'km')
    >>> unyt_array([1, 2, 3], 'km', dtype='int32')
    unyt_array([1, 2, 3], dtype=int32, units='km')
+
+Operations that convert an integer array to a new unit will convert the array to the floating point type with an equivalent size. For example, Calling ``in_units`` on a 32 bit integer array with units of kilometers will return a 32 bit floating point array.
+
+   >>> data = np.array([1, 2, 3], dtype='int32')*km
+   >>> data.in_units('mile')
+   unyt_array([0.62137121, 1.24274242, 1.86411357], dtype=float32, units='mile')
+
+In-place operations will also mutate the dtype from float to integer in these cases, again in away that will preserve the byte size of the data.
+
+   >>> data
+   unyt_array([1, 2, 3], dtype=int32, units='km')
+   >>> data.convert_to_units('mile')
+   >>> data
+   unyt_array([0.62137121, 1.24274242, 1.86411357], dtype=float32, units='mile')
+
+It is possible that arrays containing large integers (16777217 for 32 bit and 9007199254740993 for 64 bit) will lose precision when converting data to a different unit. In these cases a warning message will be printed.
 
 Writing Data with Units to Disk
 -------------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -164,7 +164,7 @@ If you make a mistake by adding two things that have different dimensions,
 code:
 
   >>> from unyt import kg, m
-  >>> 3*kg + 5*m  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+  >>> 3*kg + 5*m  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE +IGNORE_EXCEPTION_DETAIL
   Traceback (most recent call last):
   ...
   unyt.exceptions.UnitOperationError: The <ufunc 'add'> operator for
@@ -182,7 +182,7 @@ the :class:`unyt.unyt_array <unyt.array.unyt_array>` class to quickly apply unit
 
   >>> from unyt import cm, s
   >>> velocities = [10, 20, 30] * cm/s
-  >>> velocities + 12  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+  >>> velocities + 12  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE +IGNORE_EXCEPTION_DETAIL
   Traceback (most recent call last):
   ...
   unyt.exceptions.UnitOperationError: The <ufunc 'add'> operator for
@@ -254,7 +254,7 @@ If you try to convert to a unit with different dimensions, :mod:`unyt` will
 raise an error:
 
   >>> from unyt import mile
-  >>> (1.0*mile).to('lb')  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+  >>> (1.0*mile).to('lb')  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE +IGNORE_EXCEPTION_DETAIL
   Traceback (most recent call last):
   ...
   unyt.exceptions.UnitConversionError: Cannot convert between 'mile' (dim
@@ -360,7 +360,7 @@ dimensionally equivalent. The :mod:`unyt` library does have limited support for 
 But converting a more complicated compound unit will raise an error:
 
   >>> from unyt import C, T, V
-  >>> (1.0*C*T*V).in_cgs()  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+  >>> (1.0*C*T*V).in_cgs()  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE +IGNORE_EXCEPTION_DETAIL
   Traceback (most recent call last):
   ...
   unyt.exceptions.UnitsNotReducible: The unit "C*T*V" (dimensions
@@ -717,7 +717,7 @@ In practice, the unit metadata for a unit object is contained in an instance of 
 
   >>> from unyt import g
   >>> g.registry  # doctest: +ELLIPSIS
-  <unyt.unit_registry.UnitRegistry object at ...>
+  <unyt.unit_registry.UnitRegistry ...>
 
 All the unit objects in the :mod:`unyt` namespace make use of the default unit
 registry, importable as :data:`unyt.unit_registry.default_unit_registry`. This

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     setuptools
     py27: backports.functools_lru_cache
 commands =
-    pytest --cov=unyt --cov-append --doctest-modules --doctest-plus --doctest-rst --basetemp={envtmpdir}
+    pytest --cov=unyt --cov-append --doctest-modules --doctest-plus --doctest-rst --basetemp={envtmpdir} -W once
     coverage report --omit='.tox/*'
 
 [testenv:py27]

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = docs,begin,py27-min,py27-mindeps,py{27,34,35,36,37},end
+envlist = py36-docs,begin,py27-dependencies,py27-versions,py{27,34,35,36,37},end
 
 [travis]
 python =
     3.7: py37
-    3.6: docs, py36
+    3.6: py36, py36-docs
     3.5: py35
     3.4: py34
-    2.7: py27, py27-min, py27-mindeps
+    2.7: py27, py27-dependencies, py27-versions
 
 [testenv]
 setenv =
@@ -30,13 +30,7 @@ commands =
     pytest --cov=unyt --cov-append --doctest-modules --doctest-plus --doctest-rst --basetemp={envtmpdir} -W once
     coverage report --omit='.tox/*'
 
-[testenv:py27]
-commands =
-    pytest --cov=unyt --cov-append --basetemp={envtmpdir}
-    coverage report --omit='.tox/*'
-
-
-[testenv:py27-min]
+[testenv:py27-versions]
 deps =
     pytest
     sympy==1.0
@@ -51,10 +45,10 @@ deps =
     backports.functools_lru_cache
 commands =
     # don't do doctests on old numpy versions
-    pytest --cov=unyt --cov-append --basetemp={envtmpdir}
+    pytest --cov=unyt --cov-append --basetemp={envtmpdir} -W once
     coverage report --omit='.tox/*'
 
-[testenv:py27-mindeps]
+[testenv:py27-dependencies]
 deps =
     pytest
     sympy
@@ -65,22 +59,31 @@ deps =
     pytest-doctestplus
     backports.functools_lru_cache
 commands =
-    # don't do doctests on old numpy versions
-    pytest --cov=unyt --cov-append --basetemp={envtmpdir}
+    # don't do doctests in rst files due to lack of way to specify optional
+    # test dependencies there
+    pytest --cov=unyt --cov-append --doctest-modules --doctest-plus --basetemp={envtmpdir} -W once
     coverage report --omit='.tox/*'
 
-[testenv:docs]
+[testenv:py36-docs]
 changedir = docs
 deps =
   sphinx
   numpy
+  sympy
 commands =
     python -m sphinx -M html "." "_build" -W
 
 [testenv:begin]
-commands = coverage erase
+commands =
+  coverage erase
+skip_install = true
+deps =
+  coverage
 
 [testenv:end]
 commands =
     coverage report --omit='.tox/*'
     coverage html --omit='.tox/*'
+skip_install = true
+deps =
+  coverage

--- a/unyt/_testing.py
+++ b/unyt/_testing.py
@@ -11,6 +11,8 @@ Utilities for writing tests
 # The full license is in the LICENSE file, distributed with this software.
 # -----------------------------------------------------------------------------
 
+import warnings
+
 from numpy.testing import assert_allclose
 
 from unyt.array import (
@@ -82,3 +84,16 @@ def assert_allclose_units(actual, desired, rtol=1e-7, atol=0, **kwargs):
     at = at.value
 
     return assert_allclose(act, des, rt, at, **kwargs)
+
+
+def process_warning(op, message, warning_class, args=(), kwargs=None):
+    if kwargs is None:
+        kwargs = {}
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+
+        op(*args, **kwargs)
+
+        assert len(w) == 1
+        assert issubclass(w[0].category, warning_class)
+        assert str(w[0].message) == message

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1017,7 +1017,7 @@ class unyt_array(np.ndarray):
             this_equiv.convert(self, conv_unit.dimensions, **kwargs)
             self.convert_to_units(conv_unit)
         else:
-            raise InvalidUnitEquivalence(equivalence, self.units, unit)
+            raise InvalidUnitEquivalence(equivalence, self.units, conv_unit)
 
     def to_equivalent(self, unit, equivalence, **kwargs):
         """

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -109,6 +109,7 @@ from numpy import (
 )
 from numpy.core.umath import _ones_like
 from sympy import Rational
+import sys
 import warnings
 
 from unyt.dimensions import (
@@ -1798,6 +1799,15 @@ class unyt_array(np.ndarray):
         # this needs to be defined for all numpy versions, see
         # numpy issue #9081
         return type(self)(super(unyt_array, self).__pos__(), self.units)
+
+    # ensure we always use float division on python2 to avoid truncation for
+    # operations on int arrays
+    if sys.version_info < (3, 0, 0):
+        def __div__(self, other):
+            return self.__truediv__(other)
+
+        def __rdiv__(self, other):
+            return self.__rtruediv__(other)
 
     @_return_arr
     def dot(self, b, out=None):

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -142,6 +142,11 @@ from unyt.unit_registry import UnitRegistry
 NULL_UNIT = Unit()
 POWER_SIGN_MAPPING = {multiply: 1, divide: -1}
 
+__doctest_requires__ = {
+    ('unyt_array.from_pint', 'unyt_array.to_pint'): ['pint'],
+    ('unyt_array.from_astropy', 'unyt_array.to_astropy'): ['astropy'],
+}
+
 
 def _iterable(obj):
     try:
@@ -235,20 +240,6 @@ def _coerce_iterable_units(input_object, registry=None):
             # This will create a copy of the data in the iterable.
             return unyt_array(np.array(input_object), ff, registry=registry)
     return np.asarray(input_object)
-
-
-@lru_cache(maxsize=128, typed=False)
-def _unit_repr_check_same(my_units, other_units):
-    """
-    Takes a Unit object, or string of known unit symbol, and check that it
-    is compatible with this quantity. Returns Unit object.
-
-    """
-    if not my_units.same_dimensions_as(other_units):
-        raise UnitConversionError(
-            my_units, my_units.dimensions, other_units, other_units.dimensions)
-
-    return other_units
 
 
 def _sanitize_units_convert(possible_units, registry):
@@ -626,7 +617,7 @@ class unyt_array(np.ndarray):
                 new_units, (conv_factor, offset) = _em_conversion(
                     self.units, conv_data, units)
             else:
-                new_units = _unit_repr_check_same(self.units, units)
+                new_units = units
                 (conv_factor, offset) = self.units.get_conversion_factor(
                     new_units, self.dtype)
 
@@ -812,7 +803,7 @@ class unyt_array(np.ndarray):
                     self.units, conv_data, units)
                 offset = 0
             else:
-                new_units = _unit_repr_check_same(self.units, units)
+                new_units = units
                 (conversion_factor, offset) = self.units.get_conversion_factor(
                     new_units, self.dtype)
             dsize = self.dtype.itemsize

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -109,6 +109,7 @@ from numpy import (
 )
 from numpy.core.umath import _ones_like
 from sympy import Rational
+import warnings
 
 from unyt.dimensions import (
     angle,
@@ -397,7 +398,7 @@ class unyt_array(np.ndarray):
     >>> import numpy as np
     >>> a = (np.arange(8) - 4)*g/cm**3
     >>> np.abs(a)
-    unyt_array([4., 3., 2., 1., 0., 1., 2., 3.], 'g/cm**3')
+    unyt_array([4, 3, 2, 1, 0, 1, 2, 3], 'g/cm**3')
 
     and strip them when it would be annoying to deal with them.
 
@@ -495,11 +496,18 @@ class unyt_array(np.ndarray):
 
     __array_priority__ = 2.0
 
-    def __new__(cls, input_array, input_units=None, registry=None, dtype=None,
-                bypass_validation=False):
-        if dtype is None:
-            dtype = np.float64
+    def __new__(cls, input_array, units=None, registry=None, dtype=None,
+                bypass_validation=False, input_units=None):
+        # deprecate input_units in favor of units
+        if input_units is not None:
+            warnings.warn(
+                "input_units has been deprecated, please use units instead",
+                DeprecationWarning, stacklevel=2)
+        if units is not None:
+            input_units = units
         if bypass_validation is True:
+            if dtype is None:
+                dtype = input_array.dtype
             obj = input_array.view(type=cls, dtype=dtype)
             obj.units = input_units
             if registry is not None:
@@ -552,7 +560,10 @@ class unyt_array(np.ndarray):
     def __repr__(self):
         rep = super(unyt_array, self).__repr__()
         units_repr = self.units.__repr__()
-        return rep[:-1] + ', \'' + units_repr + '\')'
+        if "=" in rep:
+            return rep[:-1] + ', units=\'' + units_repr + '\')'
+        else:
+            return rep[:-1] + ', \'' + units_repr + '\')'
 
     def __str__(self):
         return str(self.view(np.ndarray)) + ' ' + str(self.units)
@@ -606,16 +617,32 @@ class unyt_array(np.ndarray):
                 raise UnitConversionError(self.units, self.units.dimensions,
                                           units, units.dimensions)
             if any(conv_data):
-                new_units, (conversion_factor, offset) = _em_conversion(
+                new_units, (conv_factor, offset) = _em_conversion(
                     self.units, conv_data, units)
             else:
                 new_units = _unit_repr_check_same(self.units, units)
-                (conversion_factor, offset) = self.units.get_conversion_factor(
-                    new_units)
+                (conv_factor, offset) = self.units.get_conversion_factor(
+                    new_units, self.dtype)
 
             self.units = new_units
             values = self.d
-            values *= conversion_factor
+            # if our dtype is an integer do the following somewhat awkward
+            # dance to change the dtype in-place. We can't use astype
+            # directly because that will create a copy and not update self
+            if self.dtype.kind in ('u', 'i'):
+                # create a copy of the original data in floating point
+                # form, it's possible this may lose precision for very
+                # large integers
+                new_dtype = 'f' + str(values.dtype.itemsize)
+                float_values = values.astype(new_dtype)
+                # change the dtypes in-place, this does not change the
+                # underlying memory buffer
+                values.dtype = new_dtype
+                self.dtype = new_dtype
+                # actually fill in the new float values now that our
+                # dtype is correct
+                np.copyto(values, float_values)
+            values *= conv_factor
 
             if offset:
                 np.subtract(values, offset, values)
@@ -717,7 +744,7 @@ class unyt_array(np.ndarray):
         >>> from unyt import dyne, erg
         >>> data = [1, 2, 3]*erg
         >>> data
-        unyt_array([1., 2., 3.], 'erg')
+        unyt_array([1, 2, 3], 'erg')
         >>> data.convert_to_mks()
         >>> data
         unyt_array([1.e-07, 2.e-07, 3.e-07], 'J')
@@ -775,9 +802,10 @@ class unyt_array(np.ndarray):
             else:
                 new_units = _unit_repr_check_same(self.units, units)
                 (conversion_factor, offset) = self.units.get_conversion_factor(
-                    new_units)
-
-            ret = np.asarray(self.ndview * conversion_factor)
+                    new_units, self.dtype)
+            new_dtype = np.dtype('f' + str(self.dtype.itemsize))
+            conversion_factor = new_dtype.type(conversion_factor)
+            ret = np.asarray(self.ndview * conversion_factor, dtype=new_dtype)
             if offset:
                 np.subtract(ret, offset, ret)
 
@@ -903,7 +931,10 @@ class unyt_array(np.ndarray):
                 self.units, conv_data, unit_system=us)
         else:
             to_units = self.units.get_base_equivalent(unit_system)
-            conv, offset = self.units.get_conversion_factor(to_units)
+            conv, offset = self.units.get_conversion_factor(
+                to_units, self.dtype)
+        new_dtype = np.dtype('f' + str(self.dtype.itemsize))
+        conv = new_dtype.type(conv)
         ret = self.v*conv
         if offset:
             ret = ret - offset
@@ -1058,9 +1089,9 @@ class unyt_array(np.ndarray):
         >>> from unyt import km
         >>> a = [3, 4, 5]*km
         >>> a
-        unyt_array([3., 4., 5.], 'km')
+        unyt_array([3, 4, 5], 'km')
         >>> a.ndarray_view()
-        array([3., 4., 5.])
+        array([3, 4, 5])
 
         This function returns a view that shares the same underlying memory
         as the original array.
@@ -1070,9 +1101,9 @@ class unyt_array(np.ndarray):
         True
         >>> b[2] = 4
         >>> b
-        array([3., 4., 4.])
+        array([3, 4, 4])
         >>> a
-        unyt_array([3., 4., 4.], 'km')
+        unyt_array([3, 4, 4], 'km')
         """
         return self.view(np.ndarray)
 
@@ -1085,10 +1116,10 @@ class unyt_array(np.ndarray):
         >>> from unyt import km
         >>> a = [3, 4, 5]*km
         >>> a
-        unyt_array([3., 4., 5.], 'km')
+        unyt_array([3, 4, 5], 'km')
         >>> b = a.to_ndarray()
         >>> b
-        array([3., 4., 5.])
+        array([3, 4, 5])
 
         The returned array will contain a copy of the data contained in
         the original array.
@@ -1199,7 +1230,7 @@ class unyt_array(np.ndarray):
         <Quantity([0 1 2 3], 'erg / centimeter ** 3')>
         >>> c = unyt_array.from_pint(b)
         >>> c
-        unyt_array([0., 1., 2., 3.], 'erg/cm**3')
+        unyt_array([0, 1, 2, 3], 'erg/cm**3')
         """
         p_units = []
         for base, exponent in arr._units.items():
@@ -1207,11 +1238,10 @@ class unyt_array(np.ndarray):
             p_units.append("%s**(%s)" % (bs, Rational(exponent)))
         p_units = "*".join(p_units)
         if isinstance(arr.magnitude, np.ndarray):
-            return unyt_array(arr.magnitude, p_units, registry=unit_registry,
-                              dtype='float64')
+            return unyt_array(arr.magnitude, p_units, registry=unit_registry)
         else:
-            return unyt_quantity(arr.magnitude, p_units,
-                                 registry=unit_registry, dtype='float64')
+            return unyt_quantity(
+                arr.magnitude, p_units, registry=unit_registry)
 
     def to_pint(self, unit_registry=None):
         """
@@ -1231,9 +1261,9 @@ class unyt_array(np.ndarray):
         >>> from unyt import cm, s
         >>> a = 4*cm**2/s
         >>> print(a)
-        4.0 cm**2/s
+        4 cm**2/s
         >>> a.to_pint()
-        <Quantity(4.0, 'centimeter ** 2 / second')>
+        <Quantity(4, 'centimeter ** 2 / second')>
         """
         if unit_registry is None:
             unit_registry = _pint.UnitRegistry()
@@ -1368,10 +1398,10 @@ class unyt_array(np.ndarray):
         >>> from unyt import km
         >>> a = [3, 4, 5]*km
         >>> a
-        unyt_array([3., 4., 5.], 'km')
+        unyt_array([3, 4, 5], 'km')
         >>> b = a.value
         >>> b
-        array([3., 4., 5.])
+        array([3, 4, 5])
 
         The returned array will contain a copy of the data contained in
         the original array.
@@ -1392,10 +1422,10 @@ class unyt_array(np.ndarray):
         >>> from unyt import km
         >>> a = [3, 4, 5]*km
         >>> a
-        unyt_array([3., 4., 5.], 'km')
+        unyt_array([3, 4, 5], 'km')
         >>> b = a.v
         >>> b
-        array([3., 4., 5.])
+        array([3, 4, 5])
 
         The returned array will contain a copy of the data contained in
         the original array.
@@ -1421,9 +1451,9 @@ class unyt_array(np.ndarray):
         >>> from unyt import km
         >>> a = [3, 4, 5]*km
         >>> a
-        unyt_array([3., 4., 5.], 'km')
+        unyt_array([3, 4, 5], 'km')
         >>> a.ndview
-        array([3., 4., 5.])
+        array([3, 4, 5])
 
         This function returns a view that shares the same underlying memory
         as the original array.
@@ -1433,9 +1463,9 @@ class unyt_array(np.ndarray):
         True
         >>> b[2] = 4
         >>> b
-        array([3., 4., 4.])
+        array([3, 4, 4])
         >>> a
-        unyt_array([3., 4., 4.], 'km')
+        unyt_array([3, 4, 4], 'km')
 
         """
         return self.view(np.ndarray)
@@ -1455,9 +1485,9 @@ class unyt_array(np.ndarray):
         >>> from unyt import km
         >>> a = [3, 4, 5]*km
         >>> a
-        unyt_array([3., 4., 5.], 'km')
+        unyt_array([3, 4, 5], 'km')
         >>> a.d
-        array([3., 4., 5.])
+        array([3, 4, 5])
 
         This function returns a view that shares the same underlying memory
         as the original array.
@@ -1467,9 +1497,9 @@ class unyt_array(np.ndarray):
         True
         >>> b[2] = 4
         >>> b
-        array([3., 4., 4.])
+        array([3, 4, 4])
         >>> a
-        unyt_array([3., 4., 4.], 'km')
+        unyt_array([3, 4, 4], 'km')
         """
         return self.view(np.ndarray)
 
@@ -1483,11 +1513,11 @@ class unyt_array(np.ndarray):
         >>> from unyt import km
         >>> a = [4, 5, 6]*km
         >>> a.unit_quantity
-        unyt_quantity(1., 'km')
+        unyt_quantity(1, 'km')
         >>> print(a + 7*a.unit_quantity)
-        [11. 12. 13.] km
+        [11 12 13] km
         """
-        return unyt_quantity(1.0, self.units)
+        return unyt_quantity(1, self.units)
 
     @property
     def uq(self):
@@ -1499,11 +1529,11 @@ class unyt_array(np.ndarray):
         >>> from unyt import km
         >>> a = [4, 5, 6]*km
         >>> a.uq
-        unyt_quantity(1., 'km')
+        unyt_quantity(1, 'km')
         >>> print(a + 7*a.uq)
-        [11. 12. 13.] km
+        [11 12 13] km
         """
-        return unyt_quantity(1.0, self.units)
+        return unyt_quantity(1, self.units)
 
     @property
     def unit_array(self):
@@ -1515,9 +1545,9 @@ class unyt_array(np.ndarray):
         >>> from unyt import km
         >>> a = [4, 5, 6]*km
         >>> a.unit_array
-        unyt_array([1., 1., 1.], 'km')
+        unyt_array([1, 1, 1], 'km')
         >>> print(a + 7*a.unit_array)
-        [11. 12. 13.] km
+        [11 12 13] km
         """
         return np.ones_like(self)
 
@@ -1531,9 +1561,9 @@ class unyt_array(np.ndarray):
         >>> from unyt import km
         >>> a = [4, 5, 6]*km
         >>> a.unit_array
-        unyt_array([1., 1., 1.], 'km')
+        unyt_array([1, 1, 1], 'km')
         >>> print(a + 7*a.unit_array)
-        [11. 12. 13.] km
+        [11 12 13] km
         """
         return np.ones_like(self)
 
@@ -1559,6 +1589,11 @@ class unyt_array(np.ndarray):
             # we need to get both the actual "out" object and a view onto it
             # in case we need to do in-place operations
             out = kwargs.pop('out')[0]
+            if out.dtype.kind in ('u', 'i'):
+                new_dtype = 'f' + str(out.dtype.itemsize)
+                float_values = out.astype(new_dtype)
+                out.dtype = new_dtype
+                np.copyto(out, float_values)
             out_func = out.view(np.ndarray)
         if len(inputs) == 1:
             # Unary ufuncs
@@ -1642,7 +1677,9 @@ class unyt_array(np.ndarray):
                                 raise UnitOperationError(ufunc, u0, u1)
                         else:
                             raise UnitOperationError(ufunc, u0, u1)
-                    conv, offset = u1.get_conversion_factor(u0)
+                    conv, offset = u1.get_conversion_factor(u0, inp1.dtype)
+                    new_dtype = np.dtype('f' + str(inp1.dtype.itemsize))
+                    conv = new_dtype.type(conv)
                     if offset is not None:
                         raise InvalidUnitOperation(
                             "Quantities with units of Fahrenheit or Celsius "
@@ -1663,8 +1700,9 @@ class unyt_array(np.ndarray):
                                     out_arr.view(np.ndarray),
                                     unit.base_value, out=out_func)
                             else:
-                                out_arr = np.multiply(out_arr.view(np.ndarray),
-                                                      unit.base_value, out=out)
+                                out_arr = np.multiply(
+                                    out_arr.view(np.ndarray), unit.base_value,
+                                    out=out_func)
                             unit = Unit(registry=unit.registry)
                 if ((u0.base_offset and u0.dimensions is temperature or
                      u1.base_offset and u1.dimensions is temperature)):
@@ -1724,12 +1762,12 @@ class unyt_array(np.ndarray):
         >>> y = x.copy()
         >>> x.fill(0)
         >>> print(x)
-        [[0. 0. 0.]
-         [0. 0. 0.]] km
+        [[0 0 0]
+         [0 0 0]] km
 
         >>> print(y)
-        [[1. 2. 3.]
-         [4. 5. 6.]] km
+        [[1 2 3]
+         [4 5 6]] km
 
         """
         return type(self)(np.copy(np.asarray(self)), self.units)
@@ -1843,7 +1881,7 @@ class unyt_quantity(unyt_array):
     >>> from unyt import g, cm
     >>> a = 12*g/cm**3
     >>> print(np.abs(a))
-    12.0 g/cm**3
+    12 g/cm**3
 
     and strip them when it would be annoying to deal with them.
 
@@ -1851,8 +1889,14 @@ class unyt_quantity(unyt_array):
     1.0791812460476249
 
     """
-    def __new__(cls, input_scalar, input_units=None, registry=None,
-                dtype=np.float64, bypass_validation=False):
+    def __new__(cls, input_scalar, units=None, registry=None,
+                dtype=None, bypass_validation=False, input_units=None):
+        if input_units is not None:
+            warnings.warn(
+                "input_units has been deprecated, please use units instead",
+                DeprecationWarning, stacklevel=2)
+        if units is not None:
+            input_units = units
         if not isinstance(input_scalar, (numeric_type, np.number, np.ndarray)):
             raise RuntimeError("unyt_quantity values must be numeric")
         if input_units is None:
@@ -1895,7 +1939,7 @@ def uconcatenate(arrs, axis=0):
     >>> A = [1, 2, 3]*cm
     >>> B = [2, 3, 4]*cm
     >>> uconcatenate((A, B))
-    unyt_array([1., 2., 3., 2., 3., 4.], 'cm')
+    unyt_array([1, 2, 3, 2, 3, 4], 'cm')
 
     """
     v = np.concatenate(arrs, axis=axis)
@@ -1929,7 +1973,7 @@ def uintersect1d(arr1, arr2, assume_unique=False):
     >>> A = [1, 2, 3]*cm
     >>> B = [2, 3, 4]*cm
     >>> uintersect1d(A, B)
-    unyt_array([2., 3.], 'cm')
+    unyt_array([2, 3], 'cm')
 
     """
     v = np.intersect1d(arr1, arr2, assume_unique=assume_unique)
@@ -1950,7 +1994,7 @@ def uunion1d(arr1, arr2):
     >>> A = [1, 2, 3]*cm
     >>> B = [2, 3, 4]*cm
     >>> uunion1d(A, B)
-    unyt_array([1., 2., 3., 4.], 'cm')
+    unyt_array([1, 2, 3, 4], 'cm')
 
     """
     v = np.union1d(arr1, arr2)
@@ -2010,8 +2054,8 @@ def uvstack(arrs):
     >>> a = [1, 2, 3]*km
     >>> b = [2, 3, 4]*km
     >>> print(uvstack([a, b]))
-    [[1. 2. 3.]
-     [2. 3. 4.]] km
+    [[1 2 3]
+     [2 3 4]] km
     """
     v = np.vstack(arrs)
     v = _validate_numpy_wrapper_units(v, arrs)
@@ -2029,13 +2073,13 @@ def uhstack(arrs):
     >>> a = [1, 2, 3]*km
     >>> b = [2, 3, 4]*km
     >>> print(uhstack([a, b]))
-    [1. 2. 3. 2. 3. 4.] km
+    [1 2 3 2 3 4] km
     >>> a = [[1],[2],[3]]*km
     >>> b = [[2],[3],[4]]*km
     >>> print(uhstack([a, b]))
-    [[1. 2.]
-     [2. 3.]
-     [3. 4.]] km
+    [[1 2]
+     [2 3]
+     [3 4]] km
     """
     v = np.hstack(arrs)
     v = _validate_numpy_wrapper_units(v, arrs)
@@ -2058,8 +2102,8 @@ def ustack(arrs, axis=0):
     >>> a = [1, 2, 3]*km
     >>> b = [2, 3, 4]*km
     >>> print(ustack([a, b]))
-    [[1. 2. 3.]
-     [2. 3. 4.]] km
+    [[1 2 3]
+     [2 3 4]] km
     """
     v = np.stack(arrs)
     v = _validate_numpy_wrapper_units(v, arrs)

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -721,7 +721,7 @@ class unyt_array(np.ndarray):
         Examples
         --------
         >>> from unyt import Newton
-        >>> data = [1, 2, 3]*Newton
+        >>> data = [1., 2., 3.]*Newton
         >>> data.convert_to_cgs()
         >>> data
         unyt_array([100000., 200000., 300000.], 'dyne')
@@ -754,9 +754,9 @@ class unyt_array(np.ndarray):
         Examples
         --------
         >>> from unyt import dyne, erg
-        >>> data = [1, 2, 3]*erg
+        >>> data = [1., 2., 3.]*erg
         >>> data
-        unyt_array([1, 2, 3], 'erg')
+        unyt_array([1., 2., 3.], 'erg')
         >>> data.convert_to_mks()
         >>> data
         unyt_array([1.e-07, 2.e-07, 3.e-07], 'J')
@@ -988,7 +988,7 @@ class unyt_array(np.ndarray):
         Example
         -------
         >>> from unyt import mile
-        >>> print((1*mile).in_mks())
+        >>> print((1.*mile).in_mks())
         1609.344 m
         """
         return self.in_base("mks")
@@ -1896,8 +1896,8 @@ class unyt_quantity(unyt_array):
     Examples
     --------
 
-    >>> a = unyt_quantity(3, 'cm')
-    >>> b = unyt_quantity(2, 'm')
+    >>> a = unyt_quantity(3., 'cm')
+    >>> b = unyt_quantity(2., 'm')
     >>> print(a + b)
     203.0 cm
     >>> print(b + a)

--- a/unyt/equivalencies.py
+++ b/unyt/equivalencies.py
@@ -469,9 +469,9 @@ class EffectiveTemperatureEquivalence(Equivalence):
     >>> print(EffectiveTemperatureEquivalence())
     effective_temperature: flux <-> temperature
     >>> from unyt import K, W, m
-    >>> (5000*K).to_equivalent('W/m**2', 'effective_temperature')
+    >>> (5000.*K).to_equivalent('W/m**2', 'effective_temperature')
     unyt_quantity(35439831.25, 'W/m**2')
-    >>> (100*W/m**2).to_equivalent('K', 'effective_temperature')
+    >>> (100.*W/m**2).to_equivalent('K', 'effective_temperature')
     unyt_quantity(204.92601414, 'K')
     """
     type_name = "effective_temperature"

--- a/unyt/equivalencies.py
+++ b/unyt/equivalencies.py
@@ -11,6 +11,8 @@ Equivalencies between different kinds of units
 # The full license is in the LICENSE file, distributed with this software.
 # -----------------------------------------------------------------------------
 
+from __future__ import division
+
 from collections import OrderedDict
 
 from unyt.dimensions import (
@@ -95,7 +97,7 @@ class NumberDensityEquivalence(Equivalence):
     def _convert(self, x, new_dims, mu=0.6):
         from unyt import physical_constants as pc
         if new_dims == number_density:
-            return np.divide(x, mu*pc.mh, out=self._get_out(x))
+            return np.true_divide(x, mu*pc.mh, out=self._get_out(x))
         elif new_dims == density:
             return np.multiply(x, mu*pc.mh, out=self._get_out(x))
 
@@ -139,7 +141,7 @@ class ThermalEquivalence(Equivalence):
         if new_dims == energy:
             return np.multiply(x, pc.kboltz, out=self._get_out(x))
         elif new_dims == temperature:
-            return np.divide(x, pc.kboltz, out=self._get_out(x))
+            return np.true_divide(x, pc.kboltz, out=self._get_out(x))
 
     def __str__(self):
         return "thermal: temperature <-> energy"
@@ -174,7 +176,7 @@ class MassEnergyEquivalence(Equivalence):
         if new_dims == energy:
             return np.multiply(x, pc.clight*pc.clight, out=self._get_out(x))
         elif new_dims == mass:
-            return np.divide(x, pc.clight*pc.clight, out=self._get_out(x))
+            return np.true_divide(x, pc.clight*pc.clight, out=self._get_out(x))
 
     def __str__(self):
         return "mass_energy: mass <-> energy"
@@ -210,32 +212,35 @@ class SpectralEquivalence(Equivalence):
         from unyt import physical_constants as pc
         if new_dims == energy:
             if x.units.dimensions == length:
-                return np.divide(pc.clight*pc.hmks, x, out=self._get_out(x))
+                return np.true_divide(
+                    pc.clight*pc.hmks, x, out=self._get_out(x))
             elif x.units.dimensions == rate:
                 return np.multiply(x, pc.hmks, out=self._get_out(x))
             elif x.units.dimensions == spatial_frequency:
                 return np.multiply(x, pc.hmks*pc.clight, out=self._get_out(x))
         elif new_dims == length:
             if x.units.dimensions == rate:
-                return np.divide(pc.clight, x, out=self._get_out(x))
+                return np.true_divide(pc.clight, x, out=self._get_out(x))
             elif x.units.dimensions == energy:
-                return np.divide(pc.hmks*pc.clight, x, out=self._get_out(x))
+                return np.true_divide(
+                    pc.hmks*pc.clight, x, out=self._get_out(x))
             elif x.units.dimensions == spatial_frequency:
-                return np.divide(1, x, out=self._get_out(x))
+                return np.true_divide(1, x, out=self._get_out(x))
         elif new_dims == rate:
             if x.units.dimensions == length:
-                return np.divide(pc.clight, x, out=self._get_out(x))
+                return np.true_divide(pc.clight, x, out=self._get_out(x))
             elif x.units.dimensions == energy:
-                return np.divide(x, pc.hmks, out=self._get_out(x))
+                return np.true_divide(x, pc.hmks, out=self._get_out(x))
             elif x.units.dimensions == spatial_frequency:
                 return np.multiply(x, pc.clight, out=self._get_out(x))
         elif new_dims == spatial_frequency:
             if x.units.dimensions == length:
-                return np.divide(1, x, out=self._get_out(x))
+                return np.true_divide(1, x, out=self._get_out(x))
             elif x.units.dimensions == energy:
-                return np.divide(x, pc.clight*pc.hmks, out=self._get_out(x))
+                return np.true_divide(
+                    x, pc.clight*pc.hmks, out=self._get_out(x))
             elif x.units.dimensions == rate:
-                return np.divide(x, pc.clight, out=self._get_out(x))
+                return np.true_divide(x, pc.clight, out=self._get_out(x))
 
     def __str__(self):
         return ("spectral: length <-> spatial_frequency <-> frequency "
@@ -304,9 +309,9 @@ class SoundSpeedEquivalence(Equivalence):
             if x.units.dimensions == velocity:
                 v2 = np.multiply(x, x, out=self._get_out(x))
                 kT = np.multiply(v2, mu*pc.mh/gamma, out=self._get_out(x))
-                return np.divide(kT, pc.kboltz, out=self._get_out(x))
+                return np.true_divide(kT, pc.kboltz, out=self._get_out(x))
             else:
-                return np.divide(x, pc.kboltz, out=self._get_out(x))
+                return np.true_divide(x, pc.kboltz, out=self._get_out(x))
         else:
             if x.units.dimensions == velocity:
                 v2 = np.multiply(x, x, out=self._get_out(x))
@@ -356,15 +361,15 @@ class LorentzEquivalence(Equivalence):
     def _convert(self, x, new_dims):
         from unyt import physical_constants as pc
         if new_dims == dimensionless:
-            beta = np.divide(x, pc.clight, out=self._get_out(x))
+            beta = np.true_divide(x, pc.clight, out=self._get_out(x))
             beta2 = np.multiply(beta, beta, out=self._get_out(x))
             inv_gamma_2 = np.subtract(1, beta2, out=self._get_out(x))
             inv_gamma = np.sqrt(inv_gamma_2, out=self._get_out(x))
-            gamma = np.divide(1., inv_gamma, out=self._get_out(x))
+            gamma = np.true_divide(1., inv_gamma, out=self._get_out(x))
             return gamma
         elif new_dims == velocity:
             gamma2 = np.multiply(x, x, out=self._get_out(x))
-            inv_gamma_2 = np.divide(1, gamma2, out=self._get_out(x))
+            inv_gamma_2 = np.true_divide(1, gamma2, out=self._get_out(x))
             beta2 = np.subtract(1, inv_gamma_2, out=self._get_out(x))
             beta = np.sqrt(beta2, out=self._get_out(x))
             return np.multiply(pc.clight, beta, out=self._get_out(x))
@@ -440,7 +445,7 @@ class ComptonEquivalence(Equivalence):
 
     def _convert(self, x, new_dims):
         from unyt import physical_constants as pc
-        return np.divide(pc.hmks/pc.clight, x, out=self._get_out(x))
+        return np.true_divide(pc.hmks/pc.clight, x, out=self._get_out(x))
 
     def __str__(self):
         return "compton: mass <-> length"
@@ -479,7 +484,7 @@ class EffectiveTemperatureEquivalence(Equivalence):
             return np.multiply(
                 pc.stefan_boltzmann_constant_mks, x4, out=self._get_out(x))
         elif new_dims == temperature:
-            T4 = np.divide(
+            T4 = np.true_divide(
                 x, pc.stefan_boltzmann_constant_mks, out=self._get_out(x))
             return np.power(T4, 0.25, out=self._get_out(x))
 

--- a/unyt/equivalencies.py
+++ b/unyt/equivalencies.py
@@ -52,7 +52,7 @@ class Equivalence(object):
         if x.units.dimensions in self._dims and new_dims in self._dims:
             return self._convert(x, new_dims, **kwargs)
         else:
-            raise InvalidUnitEquivalence(self, x, new_dims)
+            raise InvalidUnitEquivalence(self, x.units, new_dims)
 
     def _get_out(self, x):
         if self.in_place:

--- a/unyt/exceptions.py
+++ b/unyt/exceptions.py
@@ -293,12 +293,12 @@ class UnitDtypeError(Exception):
     Traceback (most recent call last):
     ...
     unyt.exceptions.UnitDtypeError: Cannot apply units to object
-    '['hello' 'world' {}]' with dtype 'object'
+    '['hello' 'world' {}]' with inferred dtype 'object'
     """
     def __init__(self, obj, dtype):
         self.obj = obj
         self.dtype = dtype
 
     def __str__(self):
-        return ("Cannot apply units to object '%s' with dtype '%s'" %
+        return ("Cannot apply units to object '%s' with inferred dtype '%s'" %
                 (self.obj, self.dtype))

--- a/unyt/exceptions.py
+++ b/unyt/exceptions.py
@@ -279,3 +279,26 @@ class IllDefinedUnitSystem(Exception):
     def __str__(self):
         return ("Cannot create unit system with inconsistent mapping from "
                 "dimensions to units. Received:\n%s" % self.units_map)
+
+
+class UnitDtypeError(Exception):
+    """Raised when applying units to invalid data
+
+    Example
+    -------
+
+    >>> from unyt import km
+    >>> ['hello', 'world', {}]*km\
+  # doctest: +IGNORE_EXCEPTION_DETAIL +NORMALIZE_WHITESPACE
+    Traceback (most recent call last):
+    ...
+    unyt.exceptions.UnitDtypeError: Cannot apply units to object
+    '['hello' 'world' {}]' with dtype 'object'
+    """
+    def __init__(self, obj, dtype):
+        self.obj = obj
+        self.dtype = dtype
+
+    def __str__(self):
+        return ("Cannot apply units to object '%s' with dtype '%s'" %
+                (self.obj, self.dtype))

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -1980,3 +1980,53 @@ def test_round():
 
     with pytest.raises(TypeError):
         round([1, 2, 3]*km)
+
+
+def test_integer_arrays():
+    from unyt import km, m, mile
+
+    def integer_semantics(inp):
+        arr = inp*km
+        assert arr.dtype.name == 'int64'
+
+        arr = np.array(inp, dtype='int32')*km
+        assert arr.dtype.name == 'int32'
+
+        ret = arr.in_units('mile')
+
+        assert arr.dtype.name == 'int32'
+        answer = (inp*km).astype('int32').to('mile')
+        assert_array_equal(ret, answer)
+        assert ret.dtype.name == 'float32'
+
+        ret = arr.in_units('m')
+        assert arr.dtype != ret.dtype
+        assert ret.dtype.name == 'float32'
+
+        arr.convert_to_units('m')
+        assert arr.dtype.name == 'float32'
+
+        arr = inp*km
+        arr.convert_to_units('mile')
+        assert arr.dtype.name == 'float64'
+
+    for foo in [[1, 2, 3], 12, -8, 0, [1, -2, 3]]:
+        integer_semantics(foo)
+
+    arr1 = [1, 2, 3]*km
+    arr2 = [4, 5, 6]*mile
+    assert (arr1 + arr2).dtype.name == 'float64'
+    assert (arr1 * arr2).dtype.name == 'int64'
+    assert (arr1 / arr2).dtype.name == 'float64'
+
+    arr1 = [1, 2, 3]*km
+    arr2 = [4, 5, 6]*m
+    assert (arr1 + arr2).dtype.name == 'float64'
+    assert (arr1 * arr2).dtype.name == 'int64'
+    assert (arr1 / arr2).dtype.name == 'float64'
+
+    arr1 = [1, 2, 3]*km
+    arr2 = [4, 5, 6]*km
+    assert (arr1 + arr2).dtype.name == 'int64'
+    assert (arr1 * arr2).dtype.name == 'int64'
+    assert (arr1 / arr2).dtype.name == 'float64'

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -1320,8 +1320,12 @@ def test_equivalencies():
 
     with pytest.raises(InvalidUnitEquivalence):
         data.convert_to_equivalent('erg', 'thermal')
-    with pytest.raises(InvalidUnitEquivalence):
+    with pytest.raises(InvalidUnitEquivalence) as excinfo:
         data.convert_to_equivalent('m', 'mass_energy')
+    assert (str(excinfo.value) ==
+            "The unit equivalence 'mass_energy: mass <-> energy' does not "
+            "exist for units 'kg' to convert to a new unit with dimensions "
+            "'(length)'.")
     with pytest.raises(InvalidUnitEquivalence):
         data.to_equivalent('erg', 'thermal')
     with pytest.raises(InvalidUnitEquivalence):

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -29,7 +29,6 @@ import warnings
 from numpy.testing import (
     assert_array_equal,
     assert_equal,
-    assert_array_almost_equal_nulp,
     assert_array_almost_equal,
     assert_almost_equal
 )
@@ -80,7 +79,7 @@ from unyt import dimensions
 
 def operate_and_compare(a, b, op, answer):
     # Test generator for unyt_arrays tests
-    assert_array_equal(op(a, b), answer)
+    assert_array_almost_equal(op(a, b), answer)
 
 
 def assert_isinstance(a, type):
@@ -565,7 +564,7 @@ def test_unit_conversions():
     from unyt.array import unyt_quantity
     from unyt.unit_object import Unit
 
-    km = unyt_quantity(1, 'km')
+    km = unyt_quantity(1., 'km', dtype='float64')
     km_in_cm = km.in_units('cm')
     cm_unit = Unit('cm')
     kpc_unit = Unit('kpc')
@@ -587,9 +586,9 @@ def test_unit_conversions():
     km.convert_to_units('kpc')
     assert km_view.base is km.base
 
-    assert_array_almost_equal_nulp(km, unyt_quantity(1, 'km'))
-    assert_array_almost_equal_nulp(km.in_cgs(), unyt_quantity(1e5, 'cm'))
-    assert_array_almost_equal_nulp(km.in_mks(), unyt_quantity(1e3, 'm'))
+    assert_array_almost_equal(km, unyt_quantity(1, 'km'))
+    assert_array_almost_equal(km.in_cgs(), unyt_quantity(1e5, 'cm'))
+    assert_array_almost_equal(km.in_mks(), unyt_quantity(1e3, 'm'))
     assert_equal(km.units, kpc_unit)
 
     assert_isinstance(km.to_ndarray(), np.ndarray)
@@ -659,8 +658,8 @@ def test_temperature_conversions():
     """
     from unyt.unit_object import InvalidUnitOperation
 
-    km = unyt_quantity(1, 'km')
-    balmy = unyt_quantity(300, 'K')
+    km = unyt_quantity(1, 'km', dtype='float64')
+    balmy = unyt_quantity(300, 'K', dtype='float64')
     balmy_F = unyt_quantity(80.33, 'degF')
     balmy_C = unyt_quantity(26.85, 'degC')
     balmy_R = unyt_quantity(540, 'R')
@@ -970,9 +969,12 @@ def binary_ufunc_comparison(ufunc, a, b):
 
 def test_ufuncs():
     for ufunc in unary_operators:
-        unary_ufunc_comparison(ufunc, unyt_array([.3, .4, .5], 'cm'))
-        unary_ufunc_comparison(ufunc, unyt_array([12, 23, 47], 'g'))
-        unary_ufunc_comparison(ufunc, unyt_array([2, 4, -6], 'erg/m**3'))
+        unary_ufunc_comparison(
+            ufunc, unyt_array([.3, .4, .5], 'cm', dtype='float64'))
+        unary_ufunc_comparison(
+            ufunc, unyt_array([12, 23, 47], 'g', dtype='float64'))
+        unary_ufunc_comparison(
+            ufunc, unyt_array([2, 4, -6], 'erg/m**3', dtype='float64'))
 
     for ufunc in binary_operators:
         # arr**arr is undefined for arrays with units because
@@ -1301,12 +1303,12 @@ def test_equivalencies():
     import unyt as u
 
     # equivalence is ignored if the conversion doesn't need one
-    data = 12*u.g
+    data = 12.*u.g
     data.convert_to_equivalent('kg', None)
     assert data.value == .012
     assert data.units == u.kg
 
-    data = 12*u.g
+    data = 12.*u.g
     data = data.to_equivalent('kg', None)
     assert data.value == .012
     assert data.units == u.kg
@@ -1378,7 +1380,7 @@ def test_equivalencies():
 
     # frequency to wavelength
 
-    nu = 1*u.MHz
+    nu = 1.*u.MHz
     lam = nu.to('km', 'spectral')
     assert_allclose_units(lam, u.clight/nu)
     nu.convert_to_units('m', 'spectral')
@@ -1388,7 +1390,7 @@ def test_equivalencies():
 
     # frequency to spatial frequency
 
-    nu = 1*u.MHz
+    nu = 1.*u.MHz
     nubar = nu.to('1/km', 'spectral')
     assert_allclose_units(nubar, nu/u.clight)
     nu.convert_to_units('1/m', 'spectral')
@@ -1398,7 +1400,7 @@ def test_equivalencies():
 
     # frequency to photon energy
 
-    nu = 1*u.MHz
+    nu = 1.*u.MHz
     E = nu.to('erg', 'spectral')
     assert_allclose_units(E, u.hmks*nu)
     nu.convert_to_units('J', 'spectral')
@@ -1536,7 +1538,7 @@ def test_equivalencies():
 
     # Schwarzschild
 
-    msun = 1*u.Msun
+    msun = 1.*u.Msun
     msun.convert_to_equivalent('km', 'schwarzschild')
     R = u.mass_sun_mks.in_units("kpc", "schwarzschild")
     assert_allclose_units(msun, R)
@@ -1549,7 +1551,7 @@ def test_equivalencies():
 
     # Compton
 
-    me = 1*u.me
+    me = 1.*u.me
     me.convert_to_units('nm', 'compton')
     length = u.me.in_units("angstrom", "compton")
     assert_allclose_units(length, me)
@@ -1617,15 +1619,15 @@ def test_electromagnetic():
 
     # Various tests of SI and CGS electromagnetic units
 
-    t = 1*u.Tesla
-    g = 1*u.gauss
+    t = 1.*u.Tesla
+    g = 1.*u.gauss
     assert t.to('gauss') == 1e4*u.gauss
     assert g.to('T') == 1e-4*u.Tesla
 
     qp_cgs = u.qp_cgs.in_units("C")
     assert_equal(qp_cgs.units.dimensions, dimensions.charge_mks)
     assert_almost_equal(qp_cgs.v, 10.0*u.qp.v/speed_of_light_cm_per_s)
-    qp = 1*u.qp_cgs
+    qp = 1.*u.qp_cgs
     qp.convert_to_units("C")
     assert_equal(qp.units.dimensions, dimensions.charge_mks)
     assert_almost_equal(qp.v, 10*u.qp.v/u.clight.v)
@@ -1644,7 +1646,7 @@ def test_electromagnetic():
     qp_mks_k = u.qp_cgs.in_units("kC")
     assert_array_almost_equal(
         qp_mks_k.v, 1.0e-2*u.qp_cgs.v/speed_of_light_cm_per_s)
-    qp = 1*u.qp_cgs
+    qp = 1.*u.qp_cgs
     qp.convert_to_units('kC')
     assert_almost_equal(qp, qp_mks_k)
 
@@ -1988,7 +1990,7 @@ def test_integer_arrays():
 
     def integer_semantics(inp):
         arr = inp*km
-        assert arr.dtype.name == 'int64'
+        assert arr.dtype == np.int_
 
         arr = np.array(inp, dtype='int32')*km
         assert arr.dtype.name == 'int32'
@@ -2009,7 +2011,7 @@ def test_integer_arrays():
 
         arr = inp*km
         arr.convert_to_units('mile')
-        assert arr.dtype.name == 'float64'
+        assert arr.dtype.name == 'float' + str(np.int_().dtype.itemsize*8)
 
     for foo in [[1, 2, 3], 12, -8, 0, [1, -2, 3]]:
         integer_semantics(foo)
@@ -2017,19 +2019,19 @@ def test_integer_arrays():
     arr1 = [1, 2, 3]*km
     arr2 = [4, 5, 6]*mile
     assert (arr1 + arr2).dtype.name == 'float64'
-    assert (arr1 * arr2).dtype.name == 'int64'
+    assert (arr1 * arr2).dtype == np.int_
     assert (arr1 / arr2).dtype.name == 'float64'
 
     arr1 = [1, 2, 3]*km
     arr2 = [4, 5, 6]*m
     assert (arr1 + arr2).dtype.name == 'float64'
-    assert (arr1 * arr2).dtype.name == 'int64'
+    assert (arr1 * arr2).dtype == np.int_
     assert (arr1 / arr2).dtype.name == 'float64'
 
     arr1 = [1, 2, 3]*km
     arr2 = [4, 5, 6]*km
-    assert (arr1 + arr2).dtype.name == 'int64'
-    assert (arr1 * arr2).dtype.name == 'int64'
+    assert (arr1 + arr2).dtype == np.int_
+    assert (arr1 * arr2).dtype == np.int_
     assert (arr1 / arr2).dtype.name == 'float64'
 
 

--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -63,10 +63,6 @@ class UnitRegistry:
         except UnitParseError:
             return False
 
-    def pop(self, item):
-        if item in self.lut:
-            del self.lut[item]
-
     @property
     def unit_system_id(self):
         """

--- a/unyt/unit_symbols.py
+++ b/unyt/unit_symbols.py
@@ -7,7 +7,7 @@ For example::
     >>> from unyt import cm, g, s
     >>> data = [3, 4, 5]*g*cm/s
     >>> print(data)
-    [3. 4. 5.] cm*g/s
+    [3 4 5] cm*g/s
 
 """
 


### PR DESCRIPTION
Up to now we assumed pretty much everywhere that data are 64 bit floats or that data will eventually get converted to 64 bit floats. This led to weird behavior if people tried to use integer or reduced precision floats, see e.g. the array printing weirdness reported in #55.

My justification for not supporting ints was that data with units are "naturally" floats. However sometimes it's important for e.g. memory layout reasons to have data as ints but still track unit metadata. Perhaps more importantly for memory layout or memory size reasons it's also important to store data in 32 bit or 16 bit precision if that's OK for the kind of data that a person is working with.

This PR changes that behavior and makes it so that we infer the dtype of data using the same rules as `np.array` for data where no dtype is explicitly specified.

We also try to keep data the same dtype but will convert from int to float to convert data to a different unit. This can lead to mutation of the dtype of an array if you do an in-place conversion which might be confusing but I think is more useful than either truncating or raising an error. See the docs I added for more detail.

This is a pretty big change. I think if this gets merged we should do a release and call it version 2.0.
