### PR TITLE
add automatic unit simplification. closes #49

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -253,7 +253,8 @@ dimensions of length::
 
 The :class:`Unit <unyt.unit_object.Unit>` class has a :meth:`simplify()
 <unyt.unit_object.Unit.simplify>` method that we can call to create a new unit
-object to represent this dimensionless conversion factor::
+object to that includes the dimensionless ratio ``m/cm`` as a constant
+coefficient::
 
   >>> (m**2/cm).simplify()
   100*m

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -268,11 +268,11 @@ Products and quotients of unit objects will not be simplified unless
 ``simplify()`` is called explicitly. However, products and quotients of arrays
 and quantities will be simplified to make interactive work more intuitive::
 
-  >>> from unyt import Watt, minute, hour
-  >>> power = [20, 40, 80] * Watt / minute
+  >>> from unyt import erg, minute, hour
+  >>> power = [20, 40, 80] * erg / minute
   >>> elapsed_time = 3*hour
   >>> print(power*elapsed_time)
-  [ 3600.  7200. 14400.] W
+  [ 3600.  7200. 14400.] erg
 
 Unit Conversions and Unit Systems
 +++++++++++++++++++++++++++++++++

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -83,16 +83,15 @@ end, days::
 
   >>> period = 2*pi*(semimajor_axis**3/(G*Mjup))**0.5
   >>> period
-  unyt_array([2.64196224e-12, 5.30291672e-12, 1.06837107e-11,
-              2.49212918e-11], 'AU**(3/2)*s/m**(3/2)')
+  unyt_array([ 152867.34547843,  306833.60667034,  618173.2944961 ,
+                1441978.11592457], 's')
   >>> period.to('d')
   unyt_array([ 1.76929798,  3.55131489,  7.1547835 , 16.68956153], 'd')
 
 Note that we haven't added any conversion factors between different units,
-that's all handled internally by :mod:`unyt`. Also note how the intermediate
-result ended up with complicated, ugly units, but the :meth:`unyt_array.to
-<unyt.array.unyt_array.to>` method was able to automagically handle the
-conversion to days.
+that's all handled internally by :mod:`unyt`. Also note how the
+:meth:`unyt_array.to <unyt.array.unyt_array.to>` method was able to
+automagically handle the conversion from seconds to days.
 
 It's also worth emphasizing that :mod:`unyt` represents powers using standard
 python syntax. This means you must use `**` and not `^`, even when writing a
@@ -229,13 +228,51 @@ controlled identically to numpy arrays, using ``numpy.setprintoptions``:
   [1.1235] km
   >>> np.set_printoptions(precision=8)
 
-Print a :math:`\rm{\LaTeX}` representation of a set of units using the :meth:`unyt.unit_object.Unit.latex_representation` function or :attr:`unyt.unit_object.Unit.latex_repr` attribute:
+Print a :math:`\rm{\LaTeX}` representation of a set of units using the
+:meth:`unyt.unit_object.Unit.latex_representation` function or
+:attr:`unyt.unit_object.Unit.latex_repr` attribute:
 
   >>> from unyt import g, cm
   >>> (g/cm**3).units.latex_representation()
   '\\frac{\\rm{g}}{\\rm{cm}^{3}}'
   >>> (g/cm**3).units.latex_repr
   '\\frac{\\rm{g}}{\\rm{cm}^{3}}'
+
+
+Simplifying Units
+-----------------
+
+Unit expressions can often be simplified to cancel pairs of factors with
+compatible dimensions. For example, we can form a unit with dimensions of length
+by dividing a unit with dimensions of length squared by another unit with
+dimensions of length::
+
+  >>> from unyt import m, cm
+  >>> m**2/cm
+  m**2/cm
+
+The :class:`Unit <unyt.unit_object.Unit>` class has a :meth:`simplify()
+<unyt.unit_object.Unit.simplify>` method that we can call to create a new unit
+object to represent this dimensionless conversion factor::
+
+  >>> (m**2/cm).simplify()
+  100*m
+
+This will also work for units that are the reciprocals of each other, for example:
+
+  >>> from unyt import s, Hz
+  >>> (s*Hz).simplify()
+  (dimensionless)
+
+Products and quotients of unit objects will not be simplified unless
+``simplify()`` is called explicitly. However, products and quotients of arrays
+and quantities will be simplified to make interactive work more intuitive::
+
+  >>> from unyt import Watt, minute, hour
+  >>> power = [20, 40, 80] * Watt / minute
+  >>> elapsed_time = 3*hour
+  >>> print(power*elapsed_time)
+  [ 3600.  7200. 14400.] W
 
 Unit Conversions and Unit Systems
 +++++++++++++++++++++++++++++++++

--- a/unyt/equivalencies.py
+++ b/unyt/equivalencies.py
@@ -505,7 +505,8 @@ class EffectiveTemperatureEquivalence(Equivalence):
             T4 = np.true_divide(
                 x, pc.stefan_boltzmann_constant_mks, out=self._get_out(x)
             )
-            return np.power(T4, 0.25, out=self._get_out(x))
+            ret = np.power(T4, 0.25, out=self._get_out(x))
+            return ret
 
     def __str__(self):
         return "effective_temperature: flux <-> temperature"

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -653,3 +653,25 @@ def test_em_unit_base_equivalent():
 def test_symbol_lut_length():
     for v in default_unit_symbol_lut.values():
         assert len(v) == 5
+
+
+def test_simplify():
+    import unyt as u
+
+    answers = {
+        u.Hz * u.s: "dimensionless",
+        u.kg / u.g: "1000",
+        u.Hz * u.s * u.km: "km",
+        u.kHz * u.s: "1000",
+        u.kHz * u.s * u.km: "1000*km",
+        u.kHz * u.s ** 2: "1000*s",
+        u.kHz * u.s ** 2 * u.km: "1000*km*s",
+        u.Hz ** -1 * u.s: "s/Hz",
+        u.Hz ** -1 * u.s * u.km: "km*s/Hz",
+        u.Hz ** 1.5 * u.s ** 1.7: "sqrt(Hz)*s**(7/10)",
+        u.Hz ** 1.5 * u.s ** 1.7 * u.km: "sqrt(Hz)*km*s**(7/10)",
+        u.m ** 2 / u.cm ** 2: "10000",
+    }
+
+    for unit, answer in answers.items():
+        assert str(unit.simplify()) == answer

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -1039,7 +1039,7 @@ def binary_ufunc_comparison(ufunc, a, b):
     ret = ufunc(a, b)
 
     if ufunc is np.multiply:
-        assert ret.units == a.units * b.units
+        assert ret.units == (a.units * b.units).simplify().as_coeff_unit()[1]
     elif ufunc in (np.divide, np.true_divide, np.arctan2):
         assert ret.units.dimensions == (a.units / b.units).dimensions
     elif ufunc in (
@@ -1715,11 +1715,12 @@ def test_equivalencies():
     assert_allclose_units(T, F.in_units("K", equivalence="effective_temperature"))
     T.convert_to_units("erg/s/cm**2", "effective_temperature")
     assert_allclose_units(T, F)
-    assert T.units == unyt_quantity(1.0, "erg/cm**2/s").units
+    assert T.units == u.Unit("erg/cm**2/s")
     assert F.units == u.W / u.m ** 2
+    assert_almost_equal(T.in_units("K", "effective_temperature").value, 1e4)
     T.convert_to_units("K", "effective_temperature")
     assert_almost_equal(T.value, 1e4)
-    assert T.units == u.K.units
+    assert T.units == u.K
 
     # to_value test
 


### PR DESCRIPTION
This adds automatic simplification of units in the form of a new `Unit.simplify()` method. It also makes it so that products and quotients of arrays with units will now automatically be simplified.

Caveats:

* I haven't done any performance benchmarking. In principle calling `simplify()` in the `__array_ufunc__` machinery is "free" because it's behind an LRU cache but I need to actually verify that. There's also an extra multiplication on the array that happens if there's any unit cancellation. In practice though most people would be "manually" doing that simplification and therefore incurring the cost of the extra multiplication anyway. All that said I still need to actually verify that the performance impact is at least acceptable.
* My tests are not *super* extensive and this is an invasive change. It's entirely possible there are untested corner cases.