### PR TITLE
add support for using unicode mu as the micro prefix.

### DIFF
--- a/unyt/_unit_lookup_table.py
+++ b/unyt/_unit_lookup_table.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 The default unit symbol lookup table.
 
@@ -11,6 +12,8 @@ The default unit symbol lookup table.
 #
 # The full license is in the LICENSE file, distributed with this software.
 # -----------------------------------------------------------------------------
+
+import sys
 
 from unyt import dimensions
 from unyt._physical_ratios import (
@@ -275,6 +278,13 @@ unit_prefixes = {
     "z": 1e-21,  # zepto
     "y": 1e-24,  # yocto
 }
+
+if sys.version_info > (3, 0, 0):
+    #  'MICRO SIGN' (U+00B5)
+    unit_prefixes["µ"] = 1e-6  # micro
+    #  'GREEK SMALL LETTER MU' (U+03BC)
+    unit_prefixes["μ"] = 1e-6  # micro
+
 
 latex_prefixes = {"u": r"\mu"}
 

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Test symbolic unit handling.
 
@@ -24,6 +25,7 @@ from numpy.testing import (
 )
 import operator
 import pytest
+import sys
 from six.moves import cPickle as pickle
 from sympy import Symbol
 from unyt._testing import assert_allclose_units
@@ -675,3 +677,16 @@ def test_simplify():
 
     for unit, answer in answers.items():
         assert str(unit.simplify()) == answer
+
+
+@pytest.mark.skipif(sys.version_info < (3, 0, 0), reason="Feature requires python3")
+def test_micro_prefix():
+    import unyt as u
+
+    # both versions of unicode mu work correctly
+    assert u.um == getattr(u, "µm")
+    assert u.um == getattr(u, "μm")
+
+    # parsing both versions works as well
+    assert u.ug == u.Unit("µg")
+    assert u.ug == u.Unit("μg")

--- a/unyt/unit_symbols.py
+++ b/unyt/unit_symbols.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Predefined useful aliases to physical units
 
@@ -19,6 +20,8 @@ For example::
 # The full license is in the LICENSE file, distributed with this software.
 # -----------------------------------------------------------------------------
 
+import sys
+
 from unyt.unit_object import Unit
 
 #
@@ -33,6 +36,11 @@ pm = picometer = Unit("pm")
 nm = nanometer = Unit("nm")
 #: micrometer
 um = micrometer = Unit("um")
+if sys.version_info > (3, 0, 0):
+    #: micrometer
+    globals()["µm"] = Unit("µm")
+    #: micrometer
+    globals()["μm"] = Unit("μm")
 #: millimeter
 mm = millimeter = Unit("mm")
 #: centimeter
@@ -67,6 +75,11 @@ pg = picogram = Unit("pg")
 ng = nanogram = Unit("ng")
 #: micogram
 ug = microgram = Unit("ug")
+if sys.version_info > (3, 0, 0):
+    #: microgram
+    globals()["µg"] = Unit("µg")
+    #: microgram
+    globals()["μg"] = Unit("μg")
 #: milligram
 mg = milligram = Unit("mg")
 #: gram
@@ -88,6 +101,11 @@ ps = picosecond = Unit("ps")
 ns = nanosecond = Unit("ns")
 #: microsecond
 us = microsecond = Unit("us")
+if sys.version_info > (3, 0, 0):
+    #: microgram
+    globals()["µs"] = Unit("µs")
+    #: microgram
+    globals()["μs"] = Unit("μs")
 #: millisecond
 ms = millisecond = Unit("ms")
 #: second


### PR DESCRIPTION
closes #34 

I tried to get this working on python2.7 and it was not worth the trouble. Works more less out of the box on python3 though so I've elected to simply make the feature python3-only. However to make the tests continue to pass on Python2.7 I had to implement this in a sort of boroque way (thus the use of `globals` and `getattr` to make sure I'm always referring to the new variables with unicode identifiers I've defined using strings).