### PR TITLE
fix incorrect conversions between inverse velocities and ohm. 

### DIFF
--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -616,6 +616,10 @@ def test_code_unit():
     assert u.get_mks_equivalent() != Unit("ohm")
     assert u.get_cgs_equivalent() == Unit("s/cm")
 
+    u = Unit("kC")
+    assert u.get_cgs_equivalent() == Unit("kesu")
+    assert u.get_cgs_equivalent().get_mks_equivalent() == u
+
     UnitSystem(ureg.unit_system_id, "code_length", "kg", "s", registry=ureg)
 
     u = Unit("cm", registry=ureg)

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -610,6 +610,12 @@ def test_code_unit():
     with pytest.raises(UnitsNotReducible):
         assert u.get_base_equivalent("cgs")
 
+    # see issue #60
+    u = Unit("s/m")
+    assert u.get_mks_equivalent() == Unit("s/m")
+    assert u.get_mks_equivalent() != Unit("ohm")
+    assert u.get_cgs_equivalent() == Unit("s/cm")
+
     UnitSystem(ureg.unit_system_id, "code_length", "kg", "s", registry=ureg)
 
     u = Unit("cm", registry=ureg)

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -607,7 +607,8 @@ def test_code_unit():
 
     u = Unit("code_magnetic_field", registry=ureg)
     assert u.get_base_equivalent("mks") == Unit("T")
-    assert u.get_base_equivalent("cgs") == Unit("gauss")
+    with pytest.raises(UnitsNotReducible):
+        assert u.get_base_equivalent("cgs")
 
     UnitSystem(ureg.unit_system_id, "code_length", "kg", "s", registry=ureg)
 

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -66,6 +66,7 @@ from unyt._physical_ratios import speed_of_light_cm_per_s
 from unyt.unit_registry import (
     default_unit_registry,
     _lookup_unit_symbol,
+    _split_prefix,
     UnitRegistry,
     UnitParseError,
 )
@@ -933,9 +934,13 @@ def _check_em_conversion(unit, to_unit=None, unit_system=None, registry=None):
     em_map = ()
     if unit == to_unit:
         return em_map
-    if (str(unit), unit.dimensions) in em_conversions:
-        em_info = em_conversions[str(unit), unit.dimensions]
-        em_unit = Unit(em_info[1], registry=registry)
+    if unit.is_atomic:
+        prefix, unit_wo_prefix = _split_prefix(str(unit), unit.registry.lut)
+    else:
+        prefix, unit_wo_prefix = "", str(unit)
+    if (unit_wo_prefix, unit.dimensions) in em_conversions:
+        em_info = em_conversions[unit_wo_prefix, unit.dimensions]
+        em_unit = Unit(prefix + em_info[1], registry=registry)
         if to_unit is None:
             cmks_in_unit = current_mks in unit.dimensions.atoms()
             cmks_in_unit_system = unit_system.units_map[current_mks]

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -858,28 +858,32 @@ def _cancel_mul(expr, registry):
 # canonical unit to convert to in that system, and floating point
 # conversion factor
 em_conversions = {
-    dims.charge_mks: (dims.charge_cgs, "esu", 0.1 * speed_of_light_cm_per_s),
-    dims.charge_cgs: (dims.charge_mks, "C", 10.0 / speed_of_light_cm_per_s),
-    dims.magnetic_field_mks: (dims.magnetic_field_cgs, "gauss", 1.0e4),
-    dims.magnetic_field_cgs: (dims.magnetic_field_mks, "T", 1.0e-4),
-    dims.current_mks: (dims.current_cgs, "statA", 0.1 * speed_of_light_cm_per_s),
-    dims.current_cgs: (dims.current_mks, "A", 10.0 / speed_of_light_cm_per_s),
-    dims.electric_potential_mks: (
+    ("C", dims.charge_mks): (dims.charge_cgs, "esu", 0.1 * speed_of_light_cm_per_s),
+    ("esu", dims.charge_cgs): (dims.charge_mks, "C", 10.0 / speed_of_light_cm_per_s),
+    ("T", dims.magnetic_field_mks): (dims.magnetic_field_cgs, "gauss", 1.0e4),
+    ("gauss", dims.magnetic_field_cgs): (dims.magnetic_field_mks, "T", 1.0e-4),
+    ("A", dims.current_mks): (dims.current_cgs, "statA", 0.1 * speed_of_light_cm_per_s),
+    ("statA", dims.current_cgs): (
+        dims.current_mks,
+        "A",
+        10.0 / speed_of_light_cm_per_s,
+    ),
+    ("V", dims.electric_potential_mks): (
         dims.electric_potential_cgs,
         "statV",
         1.0e-8 * speed_of_light_cm_per_s,
     ),
-    dims.electric_potential_cgs: (
+    ("statV", dims.electric_potential_cgs): (
         dims.electric_potential_mks,
         "V",
         1.0e8 / speed_of_light_cm_per_s,
     ),
-    dims.resistance_mks: (
+    ("ohm", dims.resistance_mks): (
         dims.resistance_cgs,
         "statohm",
         1.0e9 / (speed_of_light_cm_per_s ** 2),
     ),
-    dims.resistance_cgs: (
+    ("statohm", dims.resistance_cgs): (
         dims.resistance_mks,
         "ohm",
         1.0e-9 * speed_of_light_cm_per_s ** 2,
@@ -929,8 +933,8 @@ def _check_em_conversion(unit, to_unit=None, unit_system=None, registry=None):
     em_map = ()
     if unit == to_unit:
         return em_map
-    if unit.dimensions in em_conversions:
-        em_info = em_conversions[unit.dimensions]
+    if (str(unit), unit.dimensions) in em_conversions:
+        em_info = em_conversions[str(unit), unit.dimensions]
         em_unit = Unit(em_info[1], registry=registry)
         if to_unit is None:
             cmks_in_unit = current_mks in unit.dimensions.atoms()
@@ -961,8 +965,8 @@ def _check_em_conversion(unit, to_unit=None, unit_system=None, registry=None):
                 continue
         except MissingMKSCurrent:
             raise MKSCGSConversionError(unit)
-        if budims in em_conversions:
-            conv_unit = em_conversions[budims][1]
+        if (bu, budims) in em_conversions:
+            conv_unit = em_conversions[bu, budims][1]
             if to_unit is not None:
                 for to_unit_atom in to_unit.expr.atoms():
                     bou = str(to_unit_atom)


### PR DESCRIPTION
closes #60 

@jzuhone if you could look at this that would be awesome.

There is a behavior change (see the changed test) but I think it's worth making the behavior change to avoid the obviously incorrect behavior in #60. In principle we could also fix #60 and avoid the behavior change by just removing the conversion between ohm and statohm from the `em_conversions` dictionary however the exact same problem could also happen for the other CGS EM units, just less often because they have more unusual dimensions that won't come up in a calculation as often. Better to just remove the possibility of the bug.

Thankfully we're about to do a 2.0 release so behavior changes like this are OK if they're worth it (although should be avoided if we possibly can).