### PR TITLE
give unit registries a unit system

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -759,7 +759,7 @@ In practice, the unit metadata for a unit object is contained in an instance of 
   <unyt.unit_registry.UnitRegistry ...>
 
 All the unit objects in the :mod:`unyt` namespace make use of the default unit
-registry, importable as :data:`unyt.unit_registry.default_unit_registry`. This
+registry, importable as :data:`unyt.unit_object.default_unit_registry`. This
 registry object contains all of the real-world physical units that the
 :mod:`unyt` library ships with out of the box.
 

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -126,13 +126,8 @@ from unyt.exceptions import (
 from unyt.equivalencies import equivalence_registry
 from unyt._on_demand_imports import _astropy, _pint
 from unyt._pint_conversions import convert_pint_units
-from unyt.unit_object import (
-    _check_em_conversion,
-    _em_conversion,
-    _sanitize_unit_system,
-    Unit,
-)
-from unyt.unit_registry import UnitRegistry
+from unyt.unit_object import _check_em_conversion, _em_conversion, Unit
+from unyt.unit_registry import _sanitize_unit_system, UnitRegistry
 
 NULL_UNIT = Unit()
 POWER_SIGN_MAPPING = {multiply: 1, divide: -1}
@@ -657,7 +652,7 @@ class unyt_array(np.ndarray):
         else:
             self.convert_to_equivalent(units, equivalence, **kwargs)
 
-    def convert_to_base(self, unit_system="mks", equivalence=None, **kwargs):
+    def convert_to_base(self, unit_system=None, equivalence=None, **kwargs):
         """
         Convert the array in-place to the equivalent base units in
         the specified unit system.
@@ -669,7 +664,7 @@ class unyt_array(np.ndarray):
         ----------
         unit_system : string, optional
             The unit system to be used in the conversion. If not specified,
-            the default base units of mks are used.
+            the configured base units are used (defaults to MKS).
         equivalence : string, optional
             The equivalence you wish to use. To see which equivalencies
             are supported for this object, try the ``list_equivalencies``
@@ -927,7 +922,7 @@ class unyt_array(np.ndarray):
         else:
             return v
 
-    def in_base(self, unit_system="mks"):
+    def in_base(self, unit_system=None):
         """
         Creates a copy of this array with the data in the specified unit
         system, and returns it in that system's base units.
@@ -936,7 +931,7 @@ class unyt_array(np.ndarray):
         ----------
         unit_system : string, optional
             The unit system to be used in the conversion. If not specified,
-            the default base units of mks are used.
+            the configured default base units of are used (defaults to MKS).
 
         Examples
         --------

--- a/unyt/tests/test_unit_systems.py
+++ b/unyt/tests/test_unit_systems.py
@@ -59,6 +59,8 @@ def test_unit_system_id():
 def test_bad_unit_system():
     with pytest.raises(IllDefinedUnitSystem):
         UnitSystem("atomic", "nm", "fs", "nK", "rad")
+    with pytest.raises(IllDefinedUnitSystem):
+        UnitSystem("atomic", "nm", "fs", "nK", "rad", registry=UnitRegistry())
 
 
 def test_mks_current():

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -44,7 +44,7 @@ from unyt.dimensions import (
 )
 from unyt.exceptions import InvalidUnitOperation, UnitsNotReducible, UnitConversionError
 from unyt.unit_object import default_unit_registry, Unit, UnitParseError
-from unyt.unit_systems import UnitSystem
+from unyt.unit_systems import cgs_unit_system, UnitSystem
 from unyt._unit_lookup_table import default_unit_symbol_lut, unit_prefixes
 import unyt.unit_symbols as unit_symbols
 from unyt._physical_ratios import (
@@ -469,6 +469,19 @@ def test_base_equivalent():
 
     with pytest.raises(UnitConversionError):
         u1.get_conversion_factor(Unit("degF"))
+
+    reg = UnitRegistry(unit_system=cgs_unit_system)
+
+    u = Unit("kg", registry=reg)
+
+    assert u.get_base_equivalent() == Unit("g")
+
+    u = Unit("kg")
+
+    assert u.get_base_equivalent() == Unit("kg")
+
+    u = Unit("A")
+    assert u.get_base_equivalent(unit_system="mks") == Unit("A")
 
 
 def test_temperature_offsets():


### PR DESCRIPTION
this required a fair amount of refactoring to avoid a circular dependency generated by the fact that the unit systems currently store Unit objects. That's not actually necessary, the unit systems only need to store the units that make up the system and can generate Unit objects to return to the user when `__getitem__` is called.

Now that unit registries are associated with a unit system, the registry can be used to determine the appropriate unit system to use for a calculation. This allows the unit system to be controlled by an application by making use of a custom unit registry. Calls to in_base or get_base_equivalent will return data in the appropriately configured unit system associated with that registry.

I haven't yet added configuration for unit systems, but this at least makes it possible for application authors to have their own custom default unit system, as long as they make sure to always use their custom unit registry when they create new arrays.