### PR TITLE
fix path issues with new pip versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+# this can probably be removed at some point
+# https://github.com/pypa/pip/issues/6213
+pip-wheel-metadata/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,16 @@
 
 """The setup script."""
 
+import os
 from setuptools import setup, find_packages
-import versioneer
+import sys
+
+# ensure the current directory is on sys.path
+# so versioneer can be imported when pip uses
+# PEP 517/518 build rules
+sys.path.append(os.path.dirname(__file__))
+
+import versioneer  # NOQA
 
 with open("README.rst") as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
Since we have a pyproject.toml we opt into PEP 517/518 with the latest release of pip. One side effect is that the directory setup.py is run inside of is no longer on `sys.path`. We want that behavior though because that's how versioneer works.

Also add a gitignore rule for a new file pip is creating. According to the issue in the comment it looks like we'll probably be able to remove it after the next release of pip though.