### PR TITLE
Improve define_unit consistency with a custom registry

### DIFF
--- a/unyt/tests/test_define_unit.py
+++ b/unyt/tests/test_define_unit.py
@@ -1,6 +1,7 @@
 import pytest
 
 from unyt.unit_object import define_unit
+from unyt.unit_registry import UnitRegistry
 from unyt.array import unyt_quantity
 
 
@@ -21,6 +22,14 @@ def test_define_unit():
     volt = unyt_quantity(1.0, "V")
     second = unyt_quantity(1.0, "s")
     assert g == volt / second ** (0.5)
+
+    # Test custom registry
+    reg = UnitRegistry()
+    define_unit("Foo", (1, "m"), registry=reg)
+    define_unit("Baz", (1, "Foo**2"), registry=reg)
+    h = unyt_quantity(1, "Baz", registry=reg)
+    i = unyt_quantity(1, "m**2", registry=reg)
+    assert h == i
 
 
 def test_define_unit_error():

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -1093,7 +1093,7 @@ def define_unit(
     symbol, value, tex_repr=None, offset=None, prefixable=False, registry=None
 ):
     """
-    Define a new unit and add it to the default unit registry.
+    Define a new unit and add it to the specified unit registry.
 
     Parameters
     ----------
@@ -1138,7 +1138,7 @@ def define_unit(
         )
     if not isinstance(value, unyt_quantity):
         if _iterable(value) and len(value) == 2:
-            value = unyt_quantity(value[0], value[1])
+            value = unyt_quantity(value[0], value[1], registry=registry)
         else:
             raise RuntimeError(
                 '"value" needs to be a quantity or ' "(value, unit) tuple!"


### PR DESCRIPTION
Previously feeding a tuple with a custom registry unit would err, which probably shouldn't. See this example:

```python
from unyt import UnitRegistry, define_unit

reg = UnitRegistry()
define_unit('code_length', (1, 'm'), registry=reg)
define_unit('code_area', (1, 'code_length**2'), registry=reg)
```

It would result in `unyt.exceptions.UnitParseError: Could not find unit symbol 'code_length' in the provided symbols.` without this patch.