### PR TITLE
Tools and docs for authors writing libraries wrapping unyt

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -924,6 +924,8 @@ contains units that are compatible with the ``Simulation`` instance we named
   km
   >>> (10*units.kilometer).in_base()
   unyt_quantity(1000000., 'cm')
+  >>> (10*units.kilometer).in_units('code_length')
+  unyt_quantity(3125., 'code_length')
 
 Note how the result of the call to ``in_base()`` comes out in centimeters
 because of the the CGS unit system used by the :class:`UnitRegistry

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -900,15 +900,16 @@ to make CGS units the default unit for all operations, one might modify the
   >>> data.in_base()
   unyt_array([320., 640., 960.], 'cm')
 
-Note that the ``base_value`` parameter of ~unyt.unit_registry.UnitRegistry.add
-must be specified in MKS units. All unit data are stored internally in
-:mod:`unyt` in MKS units.
+Note that the ``base_value`` parameter of :meth:`UnitRegistry.add
+<unyt.unit_registry.UnitRegistry.add>` must be specified in MKS units. All unit
+data are stored internally in :mod:`unyt` in MKS units.
 
 You can also use two helper functions provided by :mod:`unyt`,
-~unyt.unit_systems.add_constants and ~unyt.unit_systems.add_symbols, to populate
-a namespace with a set of predefined unit symbols or physical consants. This
-namespace could correspond to the names importable from a module or the names of
-attributes of an object, or any other generic dictionary.
+:func:`unyt.unit_systems.add_constants` and
+:func:`unyt.unit_systems.add_symbols`, to populate a namespace with a set of
+predefined unit symbols or physical consants. This namespace could correspond to
+the names importable from a module or the names of attributes of an object, or
+any other generic dictionary.
 
 One example of doing this would be to make a ``UnitContainer`` class that
 contains units that are compatible with the ``Simulation`` instance we named
@@ -925,8 +926,8 @@ contains units that are compatible with the ``Simulation`` instance we named
   unyt_quantity(1000000., 'cm')
 
 Note how the result of the call to ``in_base()`` comes out in centimeters
-because of the the CGS unit system used by the ~unyt.unit_registry.UnitRegistry
-instance associated with the ``Simulation``.
+because of the the CGS unit system used by the :class:`UnitRegistry
+<unyt.unit_registry.UnitRegistry>` instance associated with the ``Simulation``.
 
 
 Writing Data with Units to Disk

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -922,9 +922,9 @@ contains units that are compatible with the ``Simulation`` instance we named
   >>> units = UnitContainer(s_cgs.registry)
   >>> units.kilometer
   km
-  >>> (10*units.kilometer).in_base()
+  >>> (10.0 * units.kilometer).in_base()
   unyt_quantity(1000000., 'cm')
-  >>> (10*units.kilometer).in_units('code_length')
+  >>> (10.0 * units.kilometer).in_units('code_length')
   unyt_quantity(3125., 'code_length')
 
 Note how the result of the call to ``in_base()`` comes out in centimeters

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -344,7 +344,7 @@ class unyt_array(np.ndarray):
     input_units : String unit name, unit symbol object, or astropy unit
         The units of the array. Powers must be specified using python
         syntax (cm**3, not cm^3).
-    registry : ~unyt.unit_registry.UnitRegistry
+    registry : :class:`unyt.unit_registry.UnitRegistry`
         The registry to create units from. If input_units is already associated
         with a unit registry and this is specified, this will be used instead
         of the registry associated with the unit object.

--- a/unyt/physical_constants.py
+++ b/unyt/physical_constants.py
@@ -24,32 +24,7 @@ For example::
 # The full license is in the LICENSE file, distributed with this software.
 # -----------------------------------------------------------------------------
 
-
-from unyt.array import unyt_quantity as _unyt_quantity
-from unyt.exceptions import UnitsNotReducible as _UnitsNotReducible
-from unyt._unit_lookup_table import physical_constants as _physical_constants
-from unyt.unit_object import Unit as _Unit
 from unyt.unit_registry import default_unit_registry as _default_unit_registry
+from unyt.unit_systems import add_constants as _add_constants
 
-
-def _generate_constants(namespace, registry):
-    for constant_name in _physical_constants:
-        value, unit_name, alternate_names = _physical_constants[constant_name]
-        for name in alternate_names + [constant_name]:
-            dim = _Unit(unit_name, registry=registry).dimensions
-            quan = _unyt_quantity(value, registry.unit_system[dim], registry=registry)
-            namespace[name] = quan
-            namespace[name + "_mks"] = _unyt_quantity(
-                value, unit_name, registry=registry
-            )
-            try:
-                namespace[name + "_cgs"] = quan.in_cgs()
-            except _UnitsNotReducible:
-                pass
-            if name == "h":
-                # backward compatibility for unyt 1.0, which defined hmks
-                namespace["hmks"] = namespace["h_mks"].copy()
-                namespace["hcgs"] = namespace["h_cgs"].copy()
-
-
-_generate_constants(globals(), registry=_default_unit_registry)
+_add_constants(globals(), registry=_default_unit_registry)

--- a/unyt/physical_constants.py
+++ b/unyt/physical_constants.py
@@ -26,7 +26,7 @@ For example::
 
 
 from unyt.array import unyt_quantity as _unyt_quantity
-from unyt.exceptions import UnitsNotReducible
+from unyt.exceptions import UnitsNotReducible as _UnitsNotReducible
 from unyt._unit_lookup_table import physical_constants as _physical_constants
 from unyt.unit_object import Unit as _Unit
 from unyt.unit_registry import default_unit_registry as _default_unit_registry
@@ -44,7 +44,7 @@ def _generate_constants(namespace, registry):
             )
             try:
                 namespace[name + "_cgs"] = quan.in_cgs()
-            except UnitsNotReducible:
+            except _UnitsNotReducible:
                 pass
             if name == "h":
                 # backward compatibility for unyt 1.0, which defined hmks

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -1094,7 +1094,7 @@ def define_unit(
     ----------
     symbol : string
         The symbol for the new unit.
-    value : tuple or ~unyt.array.unyt_quantity
+    value : tuple or :class:`unyt.array.unyt_quantity`
         The definition of the new unit in terms of some other units. For
         example, one would define a new "mph" unit with ``(1.0, "mile/hr")``
         or with ``1.0*unyt.mile/unyt.hr``
@@ -1105,7 +1105,7 @@ def define_unit(
         The default offset for the unit. If not set, an offset of 0 is assumed.
     prefixable : boolean, optional
         Whether or not the new unit can use SI prefixes. Default: False
-    registry : A ~unyt.unit_registry.UnitRegistry instance or None
+    registry : :class:`unyt.unit_registry.UnitRegistry` or None
         The unit registry to add the unit to. If None, then defaults to the
         global default unit registry. If registry is set to None then the
         unit object will be added as an attribute to the top-level :mod:`unyt`

--- a/unyt/unit_symbols.py
+++ b/unyt/unit_symbols.py
@@ -22,15 +22,7 @@ For example::
 # The full license is in the LICENSE file, distributed with this software.
 # -----------------------------------------------------------------------------
 
-from unyt._unit_lookup_table import name_alternatives as _name_alternatives
-from unyt.unit_object import Unit as _Unit
 from unyt.unit_registry import default_unit_registry as _default_unit_registry
+from unyt.unit_systems import add_symbols as _add_symbols
 
-
-def _generate_symbols(namespace, registry):
-    for canonical_name, alt_names in _name_alternatives.items():
-        for alt_name in alt_names:
-            namespace[alt_name] = _Unit(canonical_name, registry=registry)
-
-
-_generate_symbols(globals(), registry=_default_unit_registry)
+_add_symbols(globals(), registry=_default_unit_registry)

--- a/unyt/unit_systems.py
+++ b/unyt/unit_systems.py
@@ -13,12 +13,98 @@ Unit system class.
 
 from collections import OrderedDict
 from unyt import dimensions
-from unyt.exceptions import MissingMKSCurrent, IllDefinedUnitSystem
+from unyt.exceptions import MissingMKSCurrent, IllDefinedUnitSystem, UnitsNotReducible
 from unyt._unit_lookup_table import (
     default_unit_symbol_lut as default_lut,
     inv_name_alternatives,
+    name_alternatives,
+    physical_constants,
     unit_prefixes,
 )
+
+
+def add_symbols(namespace, registry):
+    """Adds the unit symbols from :mod:`unyt.unit_symbols` to a namespace
+
+    Parameters
+    ----------
+
+    namespace : dict
+       The dict to insert unit symbols into. The keys will be string
+       unit names and values will be the corresponding unit objects.
+    registry : ~unyt.unit_registry.UnitRegistry
+       The registry to create units from. Note that if you would like to
+       use a custom unit system, ensure your registry was created using
+       that unit system.
+
+    Example
+    -------
+    >>> from unyt.unit_registry import UnitRegistry
+    >>> class MyClass():
+    ...     def __init__(self):
+    ...         self.reg = UnitRegistry()
+    ...         add_symbols(vars(self), self.reg)
+    >>> foo = MyClass()
+    >>> foo.kilometer
+    km
+    >>> foo.joule
+    J
+    """
+    from unyt.unit_object import Unit
+
+    for canonical_name, alt_names in name_alternatives.items():
+        for alt_name in alt_names:
+            namespace[alt_name] = Unit(canonical_name, registry=registry)
+
+
+def add_constants(namespace, registry):
+    """Adds the quantities from ~unyt.physical_constants to a namespace
+
+    Parameters
+    ----------
+
+    namespace : dict
+       The dict to insert quantities into. The keys will be string names
+       and values will be the corresponding quantities.
+    registry : ~unyt.unit_registry.UnitRegistry
+       The registry to create units from. Note that if you would like to
+       use a custom unit system, ensure your registry was created using
+       that unit system.
+
+    Example
+    -------
+    >>> from unyt.unit_registry import UnitRegistry
+    >>> class MyClass():
+    ...     def __init__(self):
+    ...         self.reg = UnitRegistry(unit_system='cgs')
+    ...         add_constants(vars(self), self.reg)
+    >>> foo = MyClass()
+    >>> foo.gravitational_constant
+    unyt_quantity(6.67384e-08, 'cm**3/(g*s**2)')
+    >>> foo.speed_of_light
+    unyt_quantity(2.99792458e+10, 'cm/s')
+    """
+    from unyt.array import unyt_quantity
+
+    for constant_name in physical_constants:
+        value, unit_name, alternate_names = physical_constants[constant_name]
+        for name in alternate_names + [constant_name]:
+            quan = unyt_quantity(value, unit_name, registry=registry)
+            try:
+                namespace[name] = quan.in_base(unit_system=registry.unit_system)
+            except UnitsNotReducible:
+                namespace[name] = quan
+            namespace[name + "_mks"] = unyt_quantity(
+                value, unit_name, registry=registry
+            )
+            try:
+                namespace[name + "_cgs"] = quan.in_cgs()
+            except UnitsNotReducible:
+                pass
+            if name == "h":
+                # backward compatibility for unyt 1.0, which defined hmks
+                namespace["hmks"] = namespace["h_mks"].copy()
+                namespace["hcgs"] = namespace["h_cgs"].copy()
 
 
 def _split_prefix(symbol_str, unit_symbol_lut):

--- a/unyt/unit_systems.py
+++ b/unyt/unit_systems.py
@@ -32,7 +32,7 @@ def add_symbols(namespace, registry):
     namespace : dict
        The dict to insert unit symbols into. The keys will be string
        unit names and values will be the corresponding unit objects.
-    registry : ~unyt.unit_registry.UnitRegistry
+    registry : :class:`unyt.unit_registry.UnitRegistry`
        The registry to create units from. Note that if you would like to
        use a custom unit system, ensure your registry was created using
        that unit system.
@@ -58,7 +58,7 @@ def add_symbols(namespace, registry):
 
 
 def add_constants(namespace, registry):
-    """Adds the quantities from ~unyt.physical_constants to a namespace
+    """Adds the quantities from :mod:`unyt.physical_constants` to a namespace
 
     Parameters
     ----------
@@ -66,7 +66,7 @@ def add_constants(namespace, registry):
     namespace : dict
        The dict to insert quantities into. The keys will be string names
        and values will be the corresponding quantities.
-    registry : ~unyt.unit_registry.UnitRegistry
+    registry : :class:`unyt.unit_registry.UnitRegistry`
        The registry to create units from. Note that if you would like to
        use a custom unit system, ensure your registry was created using
        that unit system.


### PR DESCRIPTION
This adds two new functions, `add_symbols` and `add_constants` to the public namespace, adds tests, and documents them. It also adds some extra documentation about how library authors can deal with custom unit systems now that #62 is merged. Finally I noticed some minor doc issues (e.g. formatting problems as well as some minor organizational issues) that I've also fixed. I tried to keep my commits atomic so reviewing commit-by-commit might be easier than looking at the PR diff.