### PR TITLE
allow for floating point slop in base values when comparing units

### DIFF
--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -15,6 +15,7 @@ A class that represents a unit symbol.
 
 import copy
 import itertools
+import math
 
 from functools import lru_cache
 from keyword import iskeyword as _iskeyword
@@ -547,13 +548,16 @@ class Unit(object):
         """ Test unit equality. """
         if not isinstance(u, Unit):
             return False
-        return self.base_value == u.base_value and self.dimensions == u.dimensions
+        return (
+            math.isclose(self.base_value, u.base_value)
+            and self.dimensions == u.dimensions
+        )
 
     def __ne__(self, u):
         """ Test unit inequality. """
         if not isinstance(u, Unit):
             return True
-        if self.base_value != u.base_value:
+        if not math.isclose(self.base_value, u.base_value):
             return True
         # use 'is' comparison dimensions to avoid expensive sympy operation
         if self.dimensions is u.dimensions:


### PR DESCRIPTION
It turns out that automatic unit simplification can cause a small amount of deviation in base values between the units of an expression constructed via some complicated algebraic expression. This showed up in yt in the context of computing the standard deviation of a derived quantity. The unit's dimensions ended up correct, but the `base_value` ended up very slightly different from the `base_value` of the original unit.

This papers over that issue by allowing a very small degree of difference between the `base_value` of two equivalent units while still passing `==` equality.

This may be a dubious choice. It wasn't necessary for yt.units because we weren't doing as many floating point operations creating new unit objects whenever we multiplied or divided two arrays, although I think in principle it still would have been possible to hit this issue depending on the operation.

`math.isclose` allows a relative different of 10^-9 or smaller so only units with very slight differences will pass this check. Alternate approaches or ideas are very welcome. Happy to construct a more detailed example if you'd like that.