### PR TITLE
populate dimensions for restored json unit registries from dimensions namespace

### DIFF
--- a/unyt/tests/test_unit_registry.py
+++ b/unyt/tests/test_unit_registry.py
@@ -16,7 +16,7 @@ Test unit lookup tables and registry
 
 import pytest
 
-from unyt.dimensions import length
+from unyt.dimensions import length, energy
 from unyt.exceptions import SymbolNotFoundError, UnitParseError
 from unyt.unit_object import Unit
 from unyt.unit_registry import UnitRegistry
@@ -74,3 +74,14 @@ def test_registry_contains():
     assert "Merg" in ureg
     assert "foobar" not in ureg
     assert Unit("m", registry=ureg) in ureg
+
+
+def test_registry_json():
+    reg = UnitRegistry()
+    json_reg = reg.to_json()
+    unserialized_reg = UnitRegistry.from_json(json_reg)
+
+    assert reg.lut == unserialized_reg.lut
+
+    assert reg.lut["m"][1] is length
+    assert reg.lut["erg"][1] is energy

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -545,14 +545,6 @@ def test_latitude_longitude():
     assert_equal((lon * 180.0).in_units("deg"), deg * 360)
 
 
-def test_registry_json():
-    reg = UnitRegistry()
-    json_reg = reg.to_json()
-    unserialized_reg = UnitRegistry.from_json(json_reg)
-
-    assert_equal(reg.lut, unserialized_reg.lut)
-
-
 def test_creation_from_ytarray():
     from unyt import electrostatic_unit, elementary_charge_cgs
 

--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -15,11 +15,12 @@ A registry for units that can be added to and modified.
 
 import json
 
+from unyt import dimensions as unyt_dims
 from unyt.exceptions import SymbolNotFoundError, UnitParseError
 from unyt._unit_lookup_table import default_unit_symbol_lut, unit_prefixes
 from unyt.unit_systems import mks_unit_system, _split_prefix, unit_system_registry
 from hashlib import md5
-from sympy import sympify, srepr
+from sympy import sympify
 
 
 def _sanitize_unit_system(unit_system, obj):
@@ -228,7 +229,7 @@ class UnitRegistry:
         sanitized_lut = {}
         for k, v in self.lut.items():
             san_v = list(v)
-            repr_dims = srepr(v[1])
+            repr_dims = str(v[1])
             san_v[1] = repr_dims
             sanitized_lut[k] = tuple(san_v)
 
@@ -249,7 +250,7 @@ class UnitRegistry:
         lut = {}
         for k, v in data.items():
             unsan_v = list(v)
-            unsan_v[1] = sympify(v[1])
+            unsan_v[1] = sympify(v[1], locals=vars(unyt_dims))
             lut[k] = tuple(unsan_v)
 
         return cls(lut=lut, add_default_symbols=False)


### PR DESCRIPTION
We use "is" equality in a bunch of places when comparing dimensions. This is problematic given the current approach for the json saving and loading functionality, since `sympify` will generate distinct `Symbol` objects. We could replace the `is` equality uses with `==`, but that is anywhere from a few times to 50 times slower:

```
In [13]: from unyt.dimensions import length, energy

In [14]: %timeit length is length
34.8 ns ± 0.326 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [15]: %timeit length == length
128 ns ± 6.87 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [16]: %timeit length is not energy
39.8 ns ± 5.37 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)

In [17]: %timeit length == energy
2.38 µs ± 155 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)

In [18]: 128/34.8
Out[18]: 3.6781609195402303

In [19]: 2380/39.8
Out[19]: 59.798994974874375
```

The solution for the particular instance of this issue we're running into here is to use the `locals` keyword argument for `sympify`, which gives it access to a namespace of objects to substitute in expressions, which allows us to use the dimensions in `unyt.dimensions` to populate the dimensions of the restored unit registries.