### PR TITLE
update value of newton's constant to 2014 CODATA value. Closes #83.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,7 +19,7 @@ that can be directly imported from from the ``unyt`` namespace:
   >>> from unyt import G, Mearth, Rearth
   >>> v_esc = (2*G*Mearth/Rearth)**(1./2)
   >>> print(v_esc.to('km/s'))
-  11.254342299356159 km/s
+  11.254544657958482 km/s
 
 
 .. toctree::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -85,10 +85,10 @@ end, days::
 
   >>> period = 2*pi*(semimajor_axis**3/(G*Mjup))**0.5
   >>> period
-  unyt_array([ 152867.34547843,  306833.60667034,  618173.2944961 ,
-                1441978.11592457], 's')
+  unyt_array([ 152864.59689789,  306828.08975058,  618162.17963649,
+              1441952.18891597], 's')
   >>> period.to('d')
-  unyt_array([ 1.76929798,  3.55131489,  7.1547835 , 16.68956153], 'day')
+  unyt_array([ 1.76926617,  3.55125104,  7.15465486, 16.68926145], 'day')
 
 Note that we haven't added any conversion factors between different units,
 that's all handled internally by :mod:`unyt`. Also note how the
@@ -153,7 +153,7 @@ where :math:`\rho` is the average density of the Earth.
   5.581225129861083 g/cm**3
   >>> tff = np.sqrt(3*pi/(32*G*rho))
   >>> print(tff.to('min'))
-  14.820288514570295 min
+  14.820022043294829 min
 
 If you make a mistake by adding two things that have different dimensions,
 :mod:`unyt` will raise an error to let you know that you have a bug in your
@@ -541,7 +541,7 @@ equivalence to calculate the mass of a black hole with a radius of one AU:
 
   >>> from unyt import AU
   >>> (1.0*AU).to('Msun', equivalence='schwarzschild')
-  unyt_quantity(50658673.46804734, 'Msun')
+  unyt_quantity(50656851.7815179, 'Msun')
 
 Both the methods that convert data in-place and the ones that return a copy
 support optionally specifying equivalence. In addition to the methods described

--- a/unyt/_physical_ratios.py
+++ b/unyt/_physical_ratios.py
@@ -94,7 +94,7 @@ speed_of_light_cm_per_s = speed_of_light_m_per_s * 100.0
 standard_gravity_m_per_s2 = 9.80665
 
 # some constants
-newton_mks = 6.67384e-11
+newton_mks = 6.67408e-11
 planck_mks = 6.62606957e-34
 # permeability of Free Space
 mu_0 = 4.0e-7 * np.pi

--- a/unyt/equivalencies.py
+++ b/unyt/equivalencies.py
@@ -409,9 +409,9 @@ class SchwarzschildEquivalence(Equivalence):
     schwarzschild: mass <-> length
     >>> from unyt import Msun, AU
     >>> (10*Msun).to_equivalent('km', 'schwarzschild')
-    unyt_quantity(29.5305543, 'km')
+    unyt_quantity(29.53161626, 'km')
     >>> (1*AU).to_equivalent('Msun', 'schwarzschild')
-    unyt_quantity(50658673.46804734, 'Msun')
+    unyt_quantity(50656851.7815179, 'Msun')
     """
 
     type_name = "schwarzschild"

--- a/unyt/physical_constants.py
+++ b/unyt/physical_constants.py
@@ -10,7 +10,7 @@ For example::
     >>>
     >>> period = 2 * pi * ((1 * AU)**3 / (gravitational_constant * solar_mass))**0.5
     >>> period.in_units('day')
-    unyt_quantity(365.26893606, 'day')
+    unyt_quantity(365.26236846, 'day')
 
 .. show_all_constants::
 

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -1910,7 +1910,7 @@ def test_electromagnetic():
         data.to("C*T*V")
     with pytest.raises(UnitConversionError):
         data.convert_to_units("C*T*V")
-    assert_equal(data.in_mks(), 6.67384e-18 * u.m ** 5 / u.s ** 4)
+    assert_almost_equal(data.in_mks(), 6.67408e-18 * u.m ** 5 / u.s ** 4)
 
     mu_0 = 4.0e-7 * math.pi * u.N / u.A ** 2
     eps_0 = 8.85418781782e-12 * u.m ** -3 / u.kg * u.s ** 4 * u.A ** 2

--- a/unyt/unit_systems.py
+++ b/unyt/unit_systems.py
@@ -84,7 +84,7 @@ def add_constants(namespace, registry):
     ...         add_constants(vars(self), self.reg)
     >>> foo = MyClass()
     >>> foo.gravitational_constant
-    unyt_quantity(6.67384e-08, 'cm**3/(g*s**2)')
+    unyt_quantity(6.67408e-08, 'cm**3/(g*s**2)')
     >>> foo.speed_of_light
     unyt_quantity(2.99792458e+10, 'cm/s')
     """


### PR DESCRIPTION
See https://physics.nist.gov/cgi-bin/cuu/Value?bg

Assuming [this table on wikipedia is correct](https://en.wikipedia.org/wiki/Gravitational_constant#Modern_value), we are currently using the 2010 CODATA value. Let's update this to use the 2014 CODATA value.