### PR TITLE
ensure EM conversions only happen when we want to change unit systems

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -921,9 +921,11 @@ class unyt_array(np.ndarray):
         except MKSCGSConversionError:
             raise UnitsNotReducible(self.units, us)
         if any(conv_data):
-            to_units, (conv, offset) = _em_conversion(
-                self.units, conv_data, unit_system=us
-            )
+            um = us.units_map
+            u = self.units
+            if u.dimensions in um and u.expr == um[self.units.dimensions]:
+                return self.copy()
+            to_units, (conv, offset) = _em_conversion(u, conv_data, unit_system=us)
         else:
             to_units = self.units.get_base_equivalent(unit_system)
             conv, offset = self.units.get_conversion_factor(to_units, self.dtype)

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -1808,11 +1808,18 @@ def test_electromagnetic():
     g = 1.0 * u.gauss
     assert t.to("gauss") == 1e4 * u.gauss
     assert g.to("T") == 1e-4 * u.Tesla
+    assert t.in_mks() == t
+    assert g.in_cgs() == g
+    t.convert_to_mks()
+    assert t == 1.0 * u.Tesla
+    g.convert_to_cgs()
+    assert g == 1.0 * u.gauss
 
-    qp_cgs = u.qp_cgs.in_units("C")
-    assert_equal(qp_cgs.units.dimensions, dimensions.charge_mks)
-    assert_almost_equal(qp_cgs.v, 10.0 * u.qp.v / speed_of_light_cm_per_s)
+    qp_mks = u.qp_cgs.in_units("C")
+    assert_equal(qp_mks.units.dimensions, dimensions.charge_mks)
+    assert_almost_equal(qp_mks.v, 10.0 * u.qp.v / speed_of_light_cm_per_s)
     qp = 1.0 * u.qp_cgs
+    assert_equal(qp, u.qp_cgs.in_units("esu"))
     qp.convert_to_units("C")
     assert_equal(qp.units.dimensions, dimensions.charge_mks)
     assert_almost_equal(qp.v, 10 * u.qp.v / u.clight.v)

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -577,6 +577,9 @@ class Unit(object):
             conv_data = _check_em_conversion(
                 self.units, registry=self.registry, unit_system=unit_system
             )
+            um = unit_system.units_map
+            if self.dimensions in um and self.expr == um[self.dimensions]:
+                return self.copy()
         except MKSCGSConversionError:
             raise UnitsNotReducible(self.units, unit_system)
         if any(conv_data):


### PR DESCRIPTION
Before this PR the following script:

```python
import unyt as u
d = 12.0*u.Gauss
print(d.in_cgs().units)
```

would print `'T'`.

We need extra logic to check if we've been asked to convert to a new unit system or not. If not then we shouldn't do the EM conversion at all.

This fixes the broken test in my yt pull request that adds support for unyt.
