### PR TITLE
Update CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -118,7 +118,7 @@ We use the ``pytest`` test runner as well as the ``tox`` test wrapper to manage 
 the ``unyt`` repository, simply run ``pytest`` in the root of the repository::
 
    $ cd unyt/
-   $ py.test --doctest-modules --doctest-rst --doctest-plus
+   $ pytest --doctest-modules --doctest-rst --doctest-plus
 
 You will need to install ``pytest`` and ``pytest-doctestplus`` from ``pip`` to
 run this command. Some tests depend on ``h5py``, ``Pint``, ``astropy``,


### PR DESCRIPTION
The command line tool "pytest" was introduced in pytest-3.0. For backwards compatiblity the name "py.test" was kept. In the future the "py.test" may be deprecated. Use "pytest" instead.