### PR TITLE
Adding a test that fails for yt on appveyor.

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1712,7 +1712,12 @@ class unyt_array(np.ndarray):
                     )
         else:
             if ufunc is clip:
-                inp = (inputs[0].view(np.ndarray), inputs[1], inputs[2])
+                inp = []
+                for i in inputs:
+                    if isinstance(i, unyt_array):
+                        inp.append(i.to(inputs[0].units).view(np.ndarray))
+                    else:
+                        inp.append(i)
                 if out is not None:
                     _out = out.view(np.ndarray)
                 else:

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -2280,3 +2280,12 @@ def test_clip():
 
     assert_array_equal(data, answer)
     assert data.units == answer.units
+
+    left_edge = [0.0, 0.0, 0.0] * km
+    right_edge = [1.0, 1.0, 1.0] * km
+
+    positions = [[0.0, 0.0, 0.0], [1.0, 1.0, -0.1], [1.5, 1.0, 0.9]] * km
+    np.clip(positions, left_edge, right_edge, positions)
+    assert positions.units == left_edge.units
+    assert positions.max() == 1.0 * km
+    assert positions.min() == 0.0 * km


### PR DESCRIPTION
The clip function in yt master is causing issues when called from within the ytdata frontend.  This test seems to be the smallest way I can reproduce it.  However, I can only make it fail on appveyor.  I'm optimistic that issuing this pull-request will help track down why it's problematic, and where the (platform specific?) failure occurs.