### PR TITLE
Allow == and != for data with different units. Fixes #105.

### DIFF
--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -509,6 +509,7 @@ def test_comparisons():
     a1 = unyt_array([1, 2, 3], "cm")
     a2 = unyt_array([2, 1, 3], "cm")
     a3 = unyt_array([0.02, 0.01, 0.03], "m")
+    a4 = unyt_array([1, 2, 3], "g")
     dimless = np.array([2, 1, 3])
 
     ops = (np.less, np.less_equal, np.greater, np.greater_equal, np.equal, np.not_equal)
@@ -541,6 +542,26 @@ def test_comparisons():
     assert_equal(a1 < 2, np.less(a1, 2))
     assert_equal(2 < a1, [False, False, True])
     assert_equal(2 < a1, np.less(2, a1))
+
+    # Check that comparisons with arrays that have different units with
+    # different dimensions work properly
+    operate_and_compare(a1, a4, np.equal, [False, False, False])
+    operate_and_compare(a1, a4, np.not_equal, [True, True, True])
+
+    # check that comparing quantities returns bools and not 0-D arrays
+    el1, el4 = a1[0], a4[0]
+    assert (el1 == el4) is False
+    assert (el1 != el4) is True
+
+    # comparisons that aren't == and !=
+    with pytest.raises(UnitOperationError):
+        np.greater(a1, a4)
+    with pytest.raises(UnitOperationError):
+        a1 > a4
+    with pytest.raises(UnitOperationError):
+        np.greater(el1, el4)
+    with pytest.raises(UnitOperationError):
+        el1 > el4
 
 
 def test_unit_conversions():
@@ -1003,8 +1024,6 @@ def binary_ufunc_comparison(ufunc, a, b):
             "greater_equal",
             "less",
             "less_equal",
-            "equal",
-            "not_equal",
             "logical_and",
             "logical_or",
             "logical_xor",


### PR DESCRIPTION
Up until now we were unconditionally raising a UnitOperationError for all
comparisons of data with different units, including `equal` and `not_equal`. Due
to details of how NumPy handles this internally (I guess it happens in C code
because I don't see any of this when stepping through in pdb) numpy swallows
that error and raises a DeprecationWarning (!?) causing confusing behavior when
comparing quantities with units that are not dimensionally equivalent.

The fix is to add special handling for equal and not_equal when comparing data
with units that have different dimensions. I've also added tests for this case.

This may have negative performance implications for some workflows however I
think we have to do this in the interest of correctness. Also comparing data
with different units like this is kinda a weird thing to do and hopefully won't
impact common workflows.

Thanks to @thisch for pointing this out.