### PR TITLE
simplify creating arrays and quantities with units

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1952,7 +1952,10 @@ class unyt_quantity(unyt_array):
             )
         if units is not None:
             input_units = units
-        if not isinstance(input_scalar, (numeric_type, np.number, np.ndarray)):
+        if not (
+            bypass_validation
+            or isinstance(input_scalar, (numeric_type, np.number, np.ndarray))
+        ):
             raise RuntimeError("unyt_quantity values must be numeric")
         if input_units is None:
             units = getattr(input_scalar, "units", None)

--- a/unyt/exceptions.py
+++ b/unyt/exceptions.py
@@ -301,29 +301,3 @@ class IllDefinedUnitSystem(Exception):
             "Cannot create unit system with inconsistent mapping from "
             "dimensions to units. Received:\n%s" % self.units_map
         )
-
-
-class UnitDtypeError(Exception):
-    """Raised when applying units to invalid data
-
-    Example
-    -------
-
-    >>> from unyt import km
-    >>> ['hello', 'world', {}]*km\
-  # doctest: +IGNORE_EXCEPTION_DETAIL +NORMALIZE_WHITESPACE
-    Traceback (most recent call last):
-    ...
-    unyt.exceptions.UnitDtypeError: Cannot apply units to object
-    '['hello' 'world' {}]' with inferred dtype 'object'
-    """
-
-    def __init__(self, obj, dtype):
-        self.obj = obj
-        self.dtype = dtype
-
-    def __str__(self):
-        return "Cannot apply units to object '%s' with inferred dtype '%s'" % (
-            self.obj,
-            self.dtype,
-        )


### PR DESCRIPTION
Before:

```
In [2]: %timeit 3 * u.g
4.6 µs ± 56.2 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

After:

```
In [3]: %timeit 3 * u.g
2.94 µs ± 47.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

So about 35% faster!

I'm getting rid of `UnitDtypeError` because it wasn't tested beyond the
docstring for `UnitDtypeError` itself and `UnitOperationError` is just as
easy to understand.

I also added `__slots__` both to speed up attribute access as well as to improve
memory footprint.

`ImportCache` is needed because the caching trick won't work on the class itself because `__slots__` is defined so now I just create a singleton to hold the cache.

ping @thisch 