### PR TITLE
Fix unit hash function

### DIFF
--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -791,3 +791,10 @@ def test_percent():
 
     assert a == c
     assert c == d
+
+
+def test_equal_has_same_hash():
+    a = Unit("m")
+    b = Unit("m")
+    assert a == b
+    assert hash(a) == hash(b)

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -796,5 +796,9 @@ def test_percent():
 def test_equal_has_same_hash():
     a = Unit("m")
     b = Unit("m")
+    c = Unit("m*s/s")
+
     assert a == b
+    assert b == c
     assert hash(a) == hash(b)
+    assert hash(b) == hash(c)

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -317,7 +317,7 @@ class Unit(object):
         return self
 
     def __hash__(self):
-        return super(Unit, self).__hash__()
+        return hash(self.registry.unit_system_id) ^ hash(self.expr)
 
     # end sympy conventions
 


### PR DESCRIPTION
I discovered that the `__hash__` implementation for `Unit` is incorrect when looking at a perf bottleneck in some code; things were slowing down because the `@lru_cache` on `_multiply_units` was very rarely being hit.

The Python docs say:
> Objects which are instances of user-defined classes are hashable by default. They all compare unequal (except with themselves), and their hash value is derived from their id().

The previous implementation which just forwarded to the default hash would vary based on the `id()` of the object, and thus the `@lru_cache` would always miss.

I'm not entirely sure this implementation is correct. This is what I invented late last night, but it looks a bit unlike the `__eq__`, but my guess at a test cast that would prove this incorrect isn't failing.