### PR TITLE
correct unit hash computation to use unit registry hash data

### DIFF
--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -317,7 +317,7 @@ class Unit(object):
         return self
 
     def __hash__(self):
-        return hash(self.registry.unit_system_id) ^ hash(self.expr)
+        return int(self.registry.unit_system_id, 16) ^ hash(self.expr)
 
     # end sympy conventions
 


### PR DESCRIPTION
This implements the correction to the hash function change from #114 I discussed [here](https://github.com/yt-project/unyt/pull/114#issuecomment-569844465).