### PR TITLE
Try to speed up UnitRegistry.from_json

### DIFF
--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -14,6 +14,7 @@ A registry for units that can be added to and modified.
 
 
 import json
+from functools import lru_cache
 
 from unyt import dimensions as unyt_dims
 from unyt.exceptions import SymbolNotFoundError, UnitParseError
@@ -37,6 +38,15 @@ def _sanitize_unit_system(unit_system, obj):
     elif unit_system == "code":
         unit_system = obj.units.registry.unit_system_id
     return unit_system_registry[str(unit_system)]
+
+
+@lru_cache
+def cached_sympify(u):
+    """
+    Successive loads of unit systems produce the same calls to sympify in UnitRegistry.from_json
+    Even within a single load, this is a net gain because there will often be a few cache hits
+    """
+    return sympify(u, locals=vars(unyt_dims))
 
 
 class UnitRegistry:
@@ -250,7 +260,7 @@ class UnitRegistry:
         lut = {}
         for k, v in data.items():
             unsan_v = list(v)
-            unsan_v[1] = sympify(v[1], locals=vars(unyt_dims))
+            unsan_v[1] = cached_sympify(v[1])
             if len(unsan_v) == 4:
                 # old unit registry so we need to add SI-prefixability to the registry
                 # entry and correct the base_value to be in MKS units

--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -40,11 +40,12 @@ def _sanitize_unit_system(unit_system, obj):
     return unit_system_registry[str(unit_system)]
 
 
-@lru_cache
+@lru_cache(maxsize=128, typed=False)
 def cached_sympify(u):
     """
-    Successive loads of unit systems produce the same calls to sympify in UnitRegistry.from_json
-    Even within a single load, this is a net gain because there will often be a few cache hits
+    Successive loads of unit systems produce the same calls to sympify
+    in UnitRegistry.from_json. Even within a single load, this is a
+    net improvement because there will often be a few cache hits
     """
     return sympify(u, locals=vars(unyt_dims))
 


### PR DESCRIPTION
We have a code that does some analysis on snapshots then dumps HDF5 files which serialize a bunch of unyt_arrays and unyt_quantities. It also serializes the unit system that was created when the snapshot was opened. So when someone wants to loop over hundreds of these files which contain serialized unyt structures, the process overall is dominated by reconstituting the serialized unit registry for each file.

The `functools.lru_cache` can't be keyed on both the arguments to the `sympify` call, because the second argument is not hashable. I think this is okay because modifying the module seems like it would invalidate other things as well.