### PR TITLE
add support for matplotlib 2.2.4

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1188,25 +1188,25 @@ Plotting with Matplotlib
 Matplotlib is Unyt aware. With no additional effort, Matplotlib will label the x and y
 axes with the units.
 
-  >>> import matplotlib.pyplot as plt # doctest: +SKIP
+  >>> import matplotlib.pyplot as plt
   >>> from unyt import s, K
   >>> x = [0.0, 0.01, 0.02]*s
   >>> y = [298.15, 308.15, 318.15]*K
-  >>> plt.plot(x, y) # doctest: +SKIP
-  [<matplotlib.lines.Line2D object at ...>] # doctest: +SKIP
-  >>> plt.show() # doctest: +SKIP
+  >>> plt.plot(x, y)
+  [<matplotlib.lines.Line2D object at ...>]
+  >>> plt.show()
 
 .. image:: _static/mpl_fig1.png
 
 You can change the plotted units without affecting the original data.
 
-  >>> plt.plot(x, y, xunits="ms", yunits=("J", "thermal")) # doctest: +SKIP
-  [<matplotlib.lines.Line2D object at ...>] # doctest: +SKIP
-  >>> plt.show() # doctest: +SKIP
+  >>> plt.plot(x, y, xunits="ms", yunits=("J", "thermal"))
+  [<matplotlib.lines.Line2D object at ...>]
+  >>> plt.show()
 
 .. image:: _static/mpl_fig2.png
 
 .. note::
   
-  - This feature works in matplotlib versions 3.1 and above
+  - This feature works in Matplotlib versions 2.2.4 and above
   - Matplotlib is not a dependency of Unyt

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ python =
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
+    MPLBACKEND = agg
 recreate = true
 depends = begin
 deps =
@@ -26,7 +27,7 @@ deps =
     flake8
     black ; python_version >= '3.6.0'
     setuptools
-    matplotlib ; python_version >= '3.6.0'
+    matplotlib
 commands =
     pytest --cov=unyt --cov-append --doctest-modules --doctest-plus --doctest-rst --basetemp={envtmpdir} -W once
     coverage report --omit='.tox/*'
@@ -39,6 +40,7 @@ deps =
     h5py==2.6.0
     pint==0.6
     astropy==1.3.3
+    matplotlib==2.2.4
     coverage<5.0
     pytest-cov
     pytest-doctestplus

--- a/unyt/mpl_interface.py
+++ b/unyt/mpl_interface.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     pass
 else:
-    from unyt import unyt_array, Unit
+    from unyt import unyt_array, unyt_quantity, Unit
 
     class unyt_arrayConverter(ConversionInterface):
         """Matplotlib interface for unyt_array"""
@@ -105,3 +105,4 @@ else:
             return value.to(*unit)
 
     registry[unyt_array] = unyt_arrayConverter()
+    registry[unyt_quantity] = unyt_arrayConverter()

--- a/unyt/tests/test_mpl_interface.py
+++ b/unyt/tests/test_mpl_interface.py
@@ -13,7 +13,8 @@ check_matplotlib = pytest.mark.skipif(
 
 @pytest.fixture
 def ax(scope="module"):
-    yield _matplotlib.pyplot.figure().add_subplot()
+    fig, ax = _matplotlib.pyplot.subplots()
+    yield ax
     _matplotlib.pyplot.close()
 
 
@@ -21,7 +22,6 @@ def ax(scope="module"):
 def test_label(ax):
     x = [0, 1, 2] * s
     y = [3, 4, 5] * K
-    ax.clear()
     ax.plot(x, y)
     expected_xlabel = "$\\left(\\rm{s}\\right)$"
     assert ax.xaxis.get_label().get_text() == expected_xlabel
@@ -33,7 +33,6 @@ def test_label(ax):
 def test_convert_unit(ax):
     x = [0, 1, 2] * s
     y = [1000, 2000, 3000] * K
-    ax.clear()
     ax.plot(x, y, yunits="Celcius")
     expected = y.to("Celcius")
     line = ax.lines[0]
@@ -61,7 +60,6 @@ def test_convert_equivalency(ax):
 def test_dimensionless(ax):
     x = [0, 1, 2] * s
     y = [3, 4, 5] * K / K
-    ax.clear()
     ax.plot(x, y)
     expected_ylabel = ""
     assert ax.yaxis.get_label().get_text() == expected_ylabel
@@ -71,10 +69,15 @@ def test_dimensionless(ax):
 def test_conversionerror(ax):
     x = [0, 1, 2] * s
     y = [3, 4, 5] * K
-    ax.clear()
     ax.plot(x, y)
     ax.xaxis.callbacks.exception_handler = None
-    with pytest.raises((_matplotlib.units.ConversionError, UnitConversionError)):
+    # Newer matplotlib versions catch our exception and raise a custom
+    # ConversionError exception
+    try:
+        error_type = _matplotlib.units.ConversionError
+    except AttributeError:
+        error_type = UnitConversionError
+    with pytest.raises(error_type):
         ax.xaxis.set_units("V")
 
 
@@ -82,7 +85,6 @@ def test_conversionerror(ax):
 def test_ndarray_label(ax):
     x = [0, 1, 2] * s
     y = np.arange(3, 6)
-    ax.clear()
     ax.plot(x, y)
     expected_xlabel = "$\\left(\\rm{s}\\right)$"
     assert ax.xaxis.get_label().get_text() == expected_xlabel
@@ -94,7 +96,6 @@ def test_ndarray_label(ax):
 def test_list_label(ax):
     x = [0, 1, 2] * s
     y = [3, 4, 5]
-    ax.clear()
     ax.plot(x, y)
     expected_xlabel = "$\\left(\\rm{s}\\right)$"
     assert ax.xaxis.get_label().get_text() == expected_xlabel


### PR DESCRIPTION
This supplements #122 from @l-johnston, adding support for matplotlib 2.2.4 and refactoring a little so everything works on both versions.