### PR TITLE
fix UnitOperationError exception when the exponent is unyt_array or u…

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1666,7 +1666,7 @@ class unyt_array(np.ndarray):
                     if u1.units.is_dimensionless:
                         pass
                     else:
-                        raise UnitOperationError(ufunc, u0, u1)
+                        raise UnitOperationError(ufunc, u0, u1.units)
                 if u1.shape == ():
                     u1 = float(u1)
                 else:

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -63,7 +63,7 @@ from unyt.unit_symbols import cm, m, g, degree
 from unyt.unit_registry import UnitRegistry
 from unyt._on_demand_imports import _astropy, _h5py, _pint, NotAModule
 from unyt._physical_ratios import metallicity_sun, speed_of_light_cm_per_s
-from unyt import dimensions
+from unyt import dimensions, Unit
 
 
 def operate_and_compare(a, b, op, answer):
@@ -497,6 +497,12 @@ def test_power():
     assert_equal(cm_arr ** unyt_quantity(3), unyt_array([1, 1], "cm**3"))
     with pytest.raises(UnitOperationError):
         np.power(cm_arr, unyt_quantity(3, "g"))
+
+    try:
+        np.power(cm_arr, unyt_quantity(3, "g"))
+    except UnitOperationError as err:
+        assert isinstance(err.unit1, Unit)
+        assert isinstance(err.unit2, Unit)
 
 
 def test_comparisons():


### PR DESCRIPTION
…nyt_quantity type

Raising a value to a unyt_array type causes an AttributeError in the __str__() of UnitOperationError since unit2 is a unyt_array and not a Unit.

```
>>> from unyt import m
>>> 10**(1*m)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/d/Python/unyt/unyt/unyt/array.py", line 1669, in __array_ufunc__
    raise UnitOperationError(ufunc, u0, u1)
unyt.exceptions.UnitOperationError: <exception str() failed>
```