### PR TITLE
correct unit registries saved as pickles by yt.units

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -133,6 +133,7 @@ from unyt.unit_registry import (
     _sanitize_unit_system,
     UnitRegistry,
     default_unit_registry,
+    _correct_old_unit_registry,
 )
 
 NULL_UNIT = Unit()
@@ -1910,6 +1911,7 @@ class unyt_array(np.ndarray):
         """
         super(unyt_array, self).__setstate__(state[1:])
         unit, lut = state[0]
+        lut = _correct_old_unit_registry(lut)
         registry = UnitRegistry(lut=lut, add_default_symbols=False)
         self.units = Unit(unit, registry=registry)
 


### PR DESCRIPTION
Fixes #136.

I tried to add a test for this but since triggering this requires having yt-4.0 installed I've punted on adding the test for now. It might be easier to add the test in yt's test suite.

Using the example from Kacper's comment in #136:

```
In [1]: import shelve
   ...: dd = shelve.open("py35_local_flash_009")
   ...: run = dd["sloshing_low_res_hdf5_plt_cnt_0300"]
   ...: le = run["GridHierarchy_sloshing_low_res_hdf5_plt_cnt_0300_all"]["grid_left_edges"][0]

In [2]: le.units.registry['cm']
Out[2]: (0.01, (length), 0.0, '\\rm{cm}', False)

In [3]: le.units.base_value
Out[3]: 0.01
```

Before this PR the `base_value` of `le.units` is incorrectly read in as `1.0`.