### PR TITLE
Adding optional line in tox for python 3.8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py36-docs,begin,py35-dependencies,py35-versions,py{35,36,37,38},end
+envlist = py36-docs,begin,py35-dependencies,py35-versions,py{35,36,37,38},py38-unyt-module-test-function,end
 
 [travis]
 python =
-    3.8: py38
+    3.8: py38, py38-unyt-module-test-function
     3.7: py37
     3.6: py36, py36-docs
     3.5: py35, py35-dependencies, py35-versions
@@ -76,6 +76,11 @@ deps =
 commands =
     make clean
     python -m sphinx -M html "." "_build" -W
+
+[testenv:py38-unyt-module-test-function]
+depends = py38
+commands =
+    python -c 'import unyt; unyt.test()'
 
 [testenv:begin]
 commands =


### PR DESCRIPTION
@ngoldbaum I added a conditional line in the tox configuration to run the unyt.test() function for python3.8 (https://tox.readthedocs.io/en/latest/config.html#factors). It seems to work fine on my local environment.
