### PR TITLE
Switch from u00b5 to u03bc for micro

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -269,7 +269,7 @@ you run into issues please let us know by `opening an issue on GitHub
       >>> units.kilometer
       km
       >>> units.microsecond
-      µs
+      μs
 
   See `PR #68 <https://github.com/yt-project/unyt/pull/68>`_.
 * The ``unyt`` codebase is now automatically formatted by `black

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ deps =
     black ; python_version >= '3.6.0'
     setuptools
     matplotlib
+    docutils
 commands =
     pytest --cov=unyt --cov-append --doctest-modules --doctest-plus --doctest-rst --basetemp={envtmpdir} -W once
     coverage report --omit='.tox/*'

--- a/unyt/_unit_lookup_table.py
+++ b/unyt/_unit_lookup_table.py
@@ -506,8 +506,10 @@ def generate_name_alternatives():
         # Are we SI prefixable or not?
         if entry[4]:
             for prefix in unit_prefixes:
-                if prefix in ["u", "μ"]:
-                    used_prefix = "µ"
+                # This is specifically to work around
+                # https://github.com/yt-project/unyt/issues/145
+                if prefix in ["u", "μ", "µ"]:
+                    used_prefix = "μ"
                 else:
                     used_prefix = prefix
                 append_name(names[prefix + key], used_prefix + key, prefix + key)

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -769,8 +769,8 @@ def test_attosecond():
 def test_micro():
     from unyt import Unit
 
-    assert str(Unit("um")) == "µm"
-    assert str(Unit("us")) == "µs"
+    assert str(Unit("um")) == "μm"
+    assert str(Unit("us")) == "μs"
 
 
 def test_show_all_units_doc_table_ops():


### PR DESCRIPTION
This closes #145 .

This script:

```python
import yt
ds = yt.testing.fake_amr_ds(["density"])
p = yt.SlicePlot(ds, "x", "density")
p.set_axes_unit("um")
```

demonstrates the old and new behavior; first is old, second is new.
![old_micrometer_axes](https://user-images.githubusercontent.com/89019/84918962-ed34fb00-b086-11ea-8c0d-f3b7817605bc.png)
![new_micrometer_axes](https://user-images.githubusercontent.com/89019/84918969-f0c88200-b086-11ea-856f-9190dacb3442.png)

