### PR TITLE
raise TypeError on bad input instead of RuntimeError in unyt_quantity init

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -2022,22 +2022,24 @@ class unyt_quantity(unyt_array):
             bypass_validation
             or isinstance(input_scalar, (numeric_type, np.number, np.ndarray))
         ):
-            raise RuntimeError("unyt_quantity values must be numeric")
+            raise TypeError("unyt_quantity values must be numeric")
         if input_units is None:
             units = getattr(input_scalar, "units", None)
         else:
             units = input_units
+        scalar_array = np.asarray(input_scalar)
+        if scalar_array.size != 1:
+            raise TypeError("input_scalar must be a single scalar")
         ret = unyt_array.__new__(
             cls,
-            np.asarray(input_scalar),
+            scalar_array,
             units,
             registry,
             dtype=dtype,
             bypass_validation=bypass_validation,
             name=name,
         )
-        if ret.size > 1:
-            raise RuntimeError("unyt_quantity instances must be scalars")
+
         return ret
 
     def __round__(self):

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -2212,9 +2212,9 @@ def test_creation():
     assert new_data.units == cm
     assert new_data.units.registry is reg
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TypeError):
         unyt_quantity("hello", "cm")
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TypeError):
         unyt_quantity(np.array([1, 2, 3]), "cm")
 
 


### PR DESCRIPTION
A simple proposal to raise a somewhat more specific error upon bad input data when initialising a `unyt_quantity` object
I was writing some tests for yt to check that we caught this kind of typing error before passing them down to unyt.
Admittedly this is a breaking change for downstream code relying on RuntimeError to be raised, though I hope this is minor enough that it can be accepted. If there's a smoother path to perform such a transition ? Anything I can do to make this better ? Let me know !

for reference, the yt tests in questions are there https://github.com/yt-project/yt/pull/2703