### PR TITLE
bugfix: fix commutativity in unyt_array operators

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -123,6 +123,7 @@ from unyt.exceptions import (
     UnitOperationError,
     UnitConversionError,
     UnitsNotReducible,
+    SymbolNotFoundError,
 )
 from unyt.equivalencies import equivalence_registry
 from unyt._on_demand_imports import _astropy, _pint
@@ -1763,7 +1764,13 @@ class unyt_array(np.ndarray):
                         )
                     inp1 = np.asarray(inp1, dtype=new_dtype) * conv
             # get the unit of the result
-            mul, unit = unit_operator(u0, u1)
+            try:
+                mul, unit = unit_operator(u0, u1)
+            except SymbolNotFoundError:
+                # Some operators are not natively commutative when operands are
+                # defined within different unit registries, and conversion
+                # is defined one way but not the other.
+                mul, unit = unit_operator(u1, u0)
             # actually evaluate the ufunc
             out_arr = func(
                 inp0.view(np.ndarray), inp1.view(np.ndarray), out=out_func, **kwargs


### PR DESCRIPTION
fix https://github.com/yt-project/yt/issues/874

Here's an actualised version of the script provided by @jzuhone at the time with updated reference outputs.
```python

>>> import yt
>>> ds = yt.testing.fake_amr_ds()
>>> a = yt.YTArray([1,2,3], "cm")
>>> b = ds.arr([1,2,3], "code_length")

>>> a*b
old > SymbolNotFoundError: The symbol 'code_length' does not exist in this registry.
new > unyt_array([1, 4, 9], 'cm*code_length')

>>> b*a
old > unyt_array([1, 4, 9], 'cm*code_length')
new > unyt_array([1, 4, 9], 'cm*code_length')

>>> (a*b).in_units("code_length**2")
old > SymbolNotFoundError: The symbol 'code_length' does not exist in this registry.
new > unyt_array([1., 4., 9.], 'code_length**2')

>>> (b*a).in_units("code_length**2")
old > unyt_array([1., 4., 9.], 'code_length**2')
new > unyt_array([1., 4., 9.], 'code_length**2')
```

For reference, this issue was referenced in https://github.com/yt-project/yt/issues/2797, hence the fix.