### PR TITLE
bugfix: fix commutativity in unyt_array operators

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -123,6 +123,7 @@ from unyt.exceptions import (
     UnitOperationError,
     UnitConversionError,
     UnitsNotReducible,
+    SymbolNotFoundError,
 )
 from unyt.equivalencies import equivalence_registry
 from unyt._on_demand_imports import _astropy, _pint
@@ -160,7 +161,13 @@ def _sqrt_unit(unit):
 
 @lru_cache(maxsize=128, typed=False)
 def _multiply_units(unit1, unit2):
-    ret = (unit1 * unit2).simplify()
+    try:
+        ret = (unit1 * unit2).simplify()
+    except SymbolNotFoundError:
+        # Some operators are not natively commutative when operands are
+        # defined within different unit registries, and conversion
+        # is defined one way but not the other.
+        ret = (unit2 * unit1).simplify()
     return ret.as_coeff_unit()
 
 
@@ -195,7 +202,10 @@ def _square_unit(unit):
 
 @lru_cache(maxsize=128, typed=False)
 def _divide_units(unit1, unit2):
-    ret = (unit1 / unit2).simplify()
+    try:
+        ret = (unit1 / unit2).simplify()
+    except SymbolNotFoundError:
+        ret = (1/(unit2 / unit1).simplify()).units
     return ret.as_coeff_unit()
 
 

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -205,7 +205,7 @@ def _divide_units(unit1, unit2):
     try:
         ret = (unit1 / unit2).simplify()
     except SymbolNotFoundError:
-        ret = (1/(unit2 / unit1).simplify()).units
+        ret = (1 / (unit2 / unit1).simplify()).units
     return ret.as_coeff_unit()
 
 

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -885,11 +885,7 @@ def test_mixed_registry_operations():
     b = unyt_quantity(1, "cm")
 
     assert a + b == b + a
-    assert a - b == - (b - a)
+    assert a - b == -(b - a)
     assert a * b == b * a
-    assert b / a == b / a.in_units("cm")
-    assert a / b == a / b.in_units("cm")
-    assert b // a == b // a.in_units("cm")
-    assert a // b == a // b.in_units("cm")
-    assert b % a == b % a.in_units("cm")
-    assert a % b == b % a.in_units("cm")
+    assert_almost_equal(b / a, b / a.in_units("km"))
+    assert_almost_equal(a / b, a / b.in_units("km"))

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -28,6 +28,7 @@ import pickle
 import pytest
 from sympy import Symbol
 
+from unyt.array import unyt_quantity
 from unyt.testing import assert_allclose_units
 from unyt.unit_registry import UnitRegistry
 from unyt.dimensions import (
@@ -874,3 +875,21 @@ def test_degF():
 def test_delta_degF():
     a = 1 * Unit("delta_degF")
     assert str(a) == "1 Δ°F"
+
+
+def test_mixed_registry_operations():
+
+    reg = UnitRegistry(unit_system="cgs")
+    reg.add("fake_length", 0.001, length)
+    a = unyt_quantity(1, units="fake_length", registry=reg)
+    b = unyt_quantity(1, "cm")
+
+    assert a + b == b + a
+    assert a - b == - (b - a)
+    assert a * b == b * a
+    assert b / a == b / a.in_units("cm")
+    assert a / b == a / b.in_units("cm")
+    assert b // a == b // a.in_units("cm")
+    assert a // b == a // b.in_units("cm")
+    assert b % a == b % a.in_units("cm")
+    assert a % b == b % a.in_units("cm")

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -884,8 +884,8 @@ def test_mixed_registry_operations():
     a = unyt_quantity(1, units="fake_length", registry=reg)
     b = unyt_quantity(1, "cm")
 
-    assert a + b == b + a
-    assert a - b == -(b - a)
-    assert a * b == b * a
+    assert_almost_equal(a + b, b + a)
+    assert_almost_equal(a - b, -(b - a))
+    assert_almost_equal(a * b, b * a)
     assert_almost_equal(b / a, b / a.in_units("km"))
     assert_almost_equal(a / b, a / b.in_units("km"))


### PR DESCRIPTION
another go at https://github.com/yt-project/unyt/pull/163, and fix https://github.com/yt-project/yt/issues/874

I've added tests for both commutative and non-commutative operators. Two of them (`//` and `%`) are currently failing and I can't seem to understand why, could it be due to rounding errors ?
@jzuhone , do you have any clue ?