### PR TITLE
[WIP] Addition of `UnitOperationWarning` and `strict` kwarg to `UnitRegistry`

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1005,6 +1005,20 @@ When writing tests, it is convenient to use :mod:`unyt.testing`. In particular, 
   >>> desired = actual.to("cm")
   >>> assert_allclose_units(actual, desired)
 
+Integrating :mod:`unyt` Into a Legacy Code with Non-Strict Mode
+---------------------------------------------------------------
+
+If using a custom :class:`UnitRegistry <unyt.unit_registry.UnitRegistry>`, it
+is possible to supply ``strict=False`` when initializing. This will change the behavior
+when an invalid operation is attempted. Instead of raising a :class:`UnitOperationError <unyt.exceptions.UnitOperationError>`,
+a :class:`UnitOperationWarning <unyt.exceptions.UnitOperationError>` will be
+provided instead, units will be stripped, and the operation will return a value
+without units.
+
+This behavior is not recommended in general since many of the important benefits
+of :mod:`unyt` are lost, but it can be useful for integrating :mod:`unyt` into
+legacy code which was not previously unit-aware so that until support can be
+added gradually.
 
 Custom Unit Systems
 -------------------

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -124,6 +124,7 @@ from unyt.exceptions import (
     UnitConversionError,
     UnitsNotReducible,
     SymbolNotFoundError,
+    UnitOperationWarning
 )
 from unyt.equivalencies import equivalence_registry
 from unyt._on_demand_imports import _astropy, _pint
@@ -154,16 +155,18 @@ def _iterable(obj):
         return False
     return True
 
+
 def _unit_operation_error_raise_or_warn(ufunc, u0, u1, func, *inputs):
-    if STRICT:  # True by default
+    if u0.registry.strict and u1.registry.strict:  # True by default
         raise UnitOperationError(ufunc, u0, u1)
     else:
-        warnings.warn("Performing operation without units!")
+        warnings.warn(UnitOperationWarning(ufunc, u0, u1))
         unwrapped_inputs = [
-            i.value if isinstance(i, unyt_array) or isinstance(i, unyt_quantity)
+            i.value if isinstance(i, unyt_array)
             else i for i in inputs
         ]
         return func(*unwrapped_inputs)
+
 
 @lru_cache(maxsize=128, typed=False)
 def _sqrt_unit(unit):

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -139,6 +139,7 @@ from unyt.unit_registry import (
 
 NULL_UNIT = Unit()
 POWER_SIGN_MAPPING = {multiply: 1, divide: -1}
+STRICT = True
 
 __doctest_requires__ = {
     ("unyt_array.from_pint", "unyt_array.to_pint"): ["pint"],
@@ -153,6 +154,16 @@ def _iterable(obj):
         return False
     return True
 
+def _unit_operation_error_raise_or_warn(ufunc, u0, u1, func, *inputs):
+    if STRICT:  # True by default
+        raise UnitOperationError(ufunc, u0, u1)
+    else:
+        warnings.warn("Performing operation without units!")
+        unwrapped_inputs = [
+            i.value if isinstance(i, unyt_array) or isinstance(i, unyt_quantity)
+            else i for i in inputs
+        ]
+        return func(*unwrapped_inputs)
 
 @lru_cache(maxsize=128, typed=False)
 def _sqrt_unit(unit):
@@ -1704,12 +1715,12 @@ class unyt_array(np.ndarray):
             elif ufunc is power:
                 u1 = inp1
                 if inp0.shape != () and inp1.shape != ():
-                    raise UnitOperationError(ufunc, u0, u1)
+                    return _unit_operation_error_raise_or_warn(ufunc, u0, u1, func, *inputs)
                 if isinstance(u1, unyt_array):
                     if u1.units.is_dimensionless:
                         pass
                     else:
-                        raise UnitOperationError(ufunc, u0, u1.units)
+                        return _unit_operation_error_raise_or_warn(ufunc, u0, u1.units, func, *inputs)
                 if u1.shape == ():
                     u1 = float(u1)
                 else:
@@ -1759,9 +1770,9 @@ class unyt_array(np.ndarray):
                                         ret = bool(ret)
                                     return ret
                                 else:
-                                    raise UnitOperationError(ufunc, u0, u1)
+                                    return _unit_operation_error_raise_or_warn(ufunc, u0, u1, func, *inputs)
                         else:
-                            raise UnitOperationError(ufunc, u0, u1)
+                            return _unit_operation_error_raise_or_warn(ufunc, u0, u1, func, *inputs)
                     conv, offset = u1.get_conversion_factor(u0, inp1.dtype)
                     new_dtype = np.dtype("f" + str(inp1.dtype.itemsize))
                     conv = new_dtype.type(conv)

--- a/unyt/exceptions.py
+++ b/unyt/exceptions.py
@@ -47,6 +47,29 @@ class UnitOperationError(ValueError):
         return err
 
 
+class UnitOperationWarning(UserWarning):
+    """A warning that is raised when unit operations are not allowed but
+    when running with a UnitRegistry with strict=False. In this case,
+    the operation is allowed to continue but with unit information stripped.
+    """
+
+    def __init__(self, operation, unit1, unit2=None):
+        self.operation = operation
+        self.unit1 = unit1
+        self.unit2 = unit2
+        UserWarning.__init__(self)
+
+    def __str__(self):
+        err = (
+            'The %s operator for unyt_arrays with units "%s" '
+            '(dimensions "%s") ' % (self.operation, self.unit1, self.unit1.dimensions)
+        )
+        if self.unit2 is not None:
+            err += 'and "%s" (dimensions "%s") ' % (self.unit2, self.unit2.dimensions)
+        err += "is not well defined. Performing operation without units instead."
+        return err
+
+
 class UnitConversionError(Exception):
     """An error raised when converting to a unit with different dimensions.
 

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -56,7 +56,7 @@ from unyt.exceptions import (
     UnitConversionError,
     UnitOperationError,
     UnitParseError,
-    UnitsNotReducible,
+    UnitsNotReducible, UnitOperationWarning,
 )
 from unyt.testing import assert_allclose_units, _process_warning
 from unyt.unit_symbols import cm, m, g, degree
@@ -2423,3 +2423,15 @@ def test_kip():
 
 def test_ksi():
     assert_allclose_units(unyt_quantity(1, "lbf/inch**2"), unyt_quantity(0.001, "ksi"))
+
+
+def test_non_strict_registry():
+
+    reg = UnitRegistry(strict=False)
+
+    a1 = unyt_array([1, 2, 3], "m", registry=reg)
+    a2 = unyt_array([4, 5, 6], "kg", registry=reg)
+
+    with pytest.warns(UnitOperationWarning):
+        answer = operator.add(a1, a2)
+        assert_array_equal(answer, [5, 7, 9])

--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -55,7 +55,7 @@ class UnitRegistry:
 
     _unit_system_id = None
 
-    def __init__(self, add_default_symbols=True, lut=None, unit_system=None):
+    def __init__(self, add_default_symbols=True, lut=None, unit_system=None, strict=True):
         self._unit_object_cache = {}
         if lut:
             self.lut = lut
@@ -66,6 +66,12 @@ class UnitRegistry:
 
         if add_default_symbols:
             self.lut.update(default_unit_symbol_lut)
+
+        # This boolean determines whether to raise a UnitOperationError or
+        # strip units and provide a UnitOperationWarning if an invalid
+        # operation is attempted. The default is strict=True and this is
+        # strongly recommended.
+        self.strict = strict
 
     def __getitem__(self, key):
         try:


### PR DESCRIPTION
As discussed in https://github.com/yt-project/unyt/issues/165.

Currently have a demo working, however it's failing `test_ufunc` specifically, because it seems like the `u0` or `u1` in this case don't have a `.registry` or `.dimensions` attributes despite being a `unyt_array`. Suggestions here welcome, I'm not sure why this is the case.

Once it's working I can add some additional tests and check style.