### PR TITLE
2.8.0 fixes

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,22 +2,26 @@
 History
 =======
 
-2.7.3 (2020-10-05)
+2.8.0 (2020-10-05)
 ------------------
 
+* Dropped support for Python 3.5.
 * Add ``delta_degC`` and ``delta_degF`` units to support temperature difference
-  arithmetic. See `PR #152 <https://github.com/yt-project/unyt/pull/152>`_. Thank you
-  to Lee Johnston (@l-johnston on GitHub) for the contribution.
+  arithmetic. See `PR #152
+  <https://github.com/yt-project/unyt/pull/152>`_. Thank you to Lee Johnston
+  (@l-johnston on GitHub) for the contribution.
 * Fix an issue where a subsequent load of the unit registry with units that are
   equal but not identical leads to a crash. See `PR #158
   <https://github.com/yt-project/unyt/pull/158>`_. Thank you to Matthew Turk
   (@matthewturk on GitHub) for the initial bug report and fix.
 * Add force unit ``kip`` and pressure unit ``psi``. Thank you to P. Talley
-  (@otaithleigh on GitHub) for the contribution.
-* Fix an issue where arithmetic operations on units defined in different registries
-  and having the conversion defined in one direction would lead to a crash.
-  See `PR #164 <https://github.com/yt-project/unyt/pull/164>`_. Thank you to
-  Clément Robert (@neutrinoceros on GitHub) for the initial bug report and fix.
+  (@otaithleigh on GitHub) for the contribution. See `PR #162
+  <https://github.com/yt-project/unyt/pull/162>`_.
+* Fix an issue where arithmetic operations on units defined in different
+  registries and having the conversion defined in one direction would lead to a
+  crash.  See `PR #164 <https://github.com/yt-project/unyt/pull/164>`_. Thank
+  you to Clément Robert (@neutrinoceros on GitHub) for the initial bug report
+  and fix.
 
 
 2.7.2 (2020-06-29)

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ universal = 1
 test = pytest
 
 [tool:pytest]
-collect_ignore = ['setup.py']
 norecursedirs = benchmarks paper .*
 
 [versioneer]

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
-envlist = py36-docs,begin,py35-dependencies,py35-versions,py{35,36,37,38},py38-unyt-module-test-function,end
+envlist = py36-docs,begin,py36-dependencies,py36-versions,py{36,37,38},py38-unyt-module-test-function,end
 
 [travis]
 python =
     3.8: py38, py38-unyt-module-test-function
     3.7: py37
     3.6: py36, py36-docs
-    3.5: py35, py35-dependencies, py35-versions
 
 [testenv]
 setenv =
@@ -33,8 +32,9 @@ commands =
     pytest --cov=unyt --cov-append --doctest-modules --doctest-plus --doctest-rst --basetemp={envtmpdir} -W once
     coverage report --omit='.tox/*'
 
-[testenv:py35-versions]
+[testenv:py36-versions]
 deps =
+    docutils
     pytest
     sympy==1.2
     numpy==1.13.3
@@ -50,8 +50,9 @@ commands =
     pytest --cov=unyt --cov-append --basetemp={envtmpdir} -W once
     coverage report --omit='.tox/*'
 
-[testenv:py35-dependencies]
+[testenv:py36-dependencies]
 deps =
+    docutils
     pytest
     sympy
     numpy

--- a/unyt/mpl_interface.py
+++ b/unyt/mpl_interface.py
@@ -178,11 +178,11 @@ else:
         @property
         def label_style(self):
             """str: One of the following set, ``{'()', '[]', '/'}``.
-               These choices correspond to the following unit labels:
+            These choices correspond to the following unit labels:
 
-                 * ``'()'`` -> ``'(unit)'``
-                 * ``'[]'`` -> ``'[unit]'``
-                 * ``'/'`` -> ``'q_x / unit'``
+              * ``'()'`` -> ``'(unit)'``
+              * ``'[]'`` -> ``'[unit]'``
+              * ``'/'`` -> ``'q_x / unit'``
             """
             return self._labelstyle
 


### PR DESCRIPTION
* Fix compatibility with the newest black version (the docstring in `mpl_interface.py`).
* Drop python3.5 testing and support. Ultimately this is caused by `pytest-doctest-plus` dropping support for 3.5 and breaking. Python 3.5 is EOL so let's just drop support. We're probably going to need to drop support for python3.6 and add support for 3.9 soon but I'll deal with that later.
* Remove a line from `setup.cfg` that wasn't doing anything and that pytest was complaining about.

Once this is merged I'll tag 2.8.0 and do a release. I may need to do some more if there are test failures I didn't catch locally.