### PR TITLE
Fix #179 by handling matplotlib case for limits

### DIFF
--- a/unyt/mpl_interface.py
+++ b/unyt/mpl_interface.py
@@ -102,12 +102,20 @@ else:
 
             Unit object
             """
-            name = getattr(x, "name", "")
+            # In the case where the first matplotlib command is setting limits,
+            # x may be a tuple of length two (with the same units).
+            if isinstance(x, tuple):
+                name = getattr(x[0], "name", "")
+                units = x[0].units
+            else:
+                name = getattr(x, "name", "")
+                units = x.units
+
             # maintain a mapping between Axis and name since Axis does not point to
             # its underlying data and we want to propagate the name to the axis
             # label in the subsequent call to axisinfo
             unyt_arrayConverter._axisnames[axis] = name if name is not None else ""
-            return x.units
+            return units
 
         @staticmethod
         def convert(value, unit, axis):

--- a/unyt/tests/test_mpl_interface.py
+++ b/unyt/tests/test_mpl_interface.py
@@ -234,3 +234,9 @@ def test_multiple_subplots():
     assert generated_labels == expected_labels
     _matplotlib.pyplot.close()
     matplotlib_support.disable()
+
+
+@check_matplotlib
+def test_empty_plot(ax):
+    ax.set_xlim(*unyt_array([0, 1], "s"))
+    _matplotlib.pyplot.close()


### PR DESCRIPTION
Fixes #179 by handling the case where a tuple is passed to `default_units` (which occurs when the plots is empty and a limit call is made). I've also added a test.

Perhaps @l-johnston would like to take a look at this.