### PR TITLE
fix: Apply Black and update usage docs code

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1122,7 +1122,7 @@ HDF5 Files
 
 The :mod:`unyt` library provides a hook for writing data both to a new HDF5 file and an existing file and then subsequently reading that data back in to restore the array. This works via the :meth:`unyt_array.write_hdf5 <unyt.array.unyt_array.write_hdf5>` and :meth:`unyt_array.from_hdf5 <unyt.array.unyt_array.from_hdf5>` methods. The simplest way to use these functions is to write data to a file that does not exist yet:
 
-  >>> from unyt import cm
+  >>> from unyt import cm, unyt_array
   >>> import os
   >>> data = [1, 2, 3]*cm
   >>> data.write_hdf5('my_data.h5')
@@ -1143,7 +1143,7 @@ the data to be saved in a particular group or dataset in the file:
 
 You can even write to files and groups that already exist:
 
-  >>> with h5py.File('my_data.h5') as f:
+  >>> with h5py.File('my_data.h5', 'w') as f:
   ...     g = f.create_group('my_custom_group')
   ...
   >>> data.write_hdf5('my_data.h5', group_name='my_custom_group')

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1898,7 +1898,7 @@ class unyt_array(np.ndarray):
         self.name = getattr(obj, "name", None)
 
     def __pos__(self):
-        """ Posify the data. """
+        """Posify the data."""
         # this needs to be defined for all numpy versions, see
         # numpy issue #9081
         return type(self)(super(unyt_array, self).__pos__(), self.units)

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -383,7 +383,7 @@ class Unit(object):
         return self.__mul__(u)
 
     def __mul__(self, u):
-        """ Multiply Unit with u (Unit object). """
+        """Multiply Unit with u (Unit object)."""
         if not getattr(u, "is_Unit", False):
             data = np.array(u, subok=True)
             unit = getattr(u, "units", None)
@@ -429,7 +429,7 @@ class Unit(object):
         )
 
     def __truediv__(self, u):
-        """ Divide Unit by u (Unit object). """
+        """Divide Unit by u (Unit object)."""
         if not isinstance(u, Unit):
             if isinstance(u, (numeric_type, list, tuple, np.ndarray)):
                 from unyt.array import unyt_quantity
@@ -467,7 +467,7 @@ class Unit(object):
         return u * self ** -1
 
     def __pow__(self, p):
-        """ Take Unit to power p (float). """
+        """Take Unit to power p (float)."""
         try:
             p = Rational(str(p)).limit_denominator()
         except (ValueError, TypeError):
@@ -488,7 +488,7 @@ class Unit(object):
         )
 
     def __eq__(self, u):
-        """ Test unit equality. """
+        """Test unit equality."""
         if not isinstance(u, Unit):
             return False
         return (
@@ -497,7 +497,7 @@ class Unit(object):
         )
 
     def __ne__(self, u):
-        """ Test unit inequality. """
+        """Test unit inequality."""
         if not isinstance(u, Unit):
             return True
         if not math.isclose(self.base_value, u.base_value):


### PR DESCRIPTION
This PR simply gets the CI passing (in local runs of `tox` and in GitHub Actions) so that PR #187 can proceed smoothly. It just applies Black to the code base to take care of the space differences that [Black `v21.4b0+` now enforces](https://black.readthedocs.io/en/stable/change_log.html#id6) and then in the docs adds in a missing import of `unt_array` and then adds a write option to a `h5py.File` call (perhaps a somewhat recent change in `h5py`?).

I don't think that `yt` does squash and merge commits like I usually do, but if that _is_ something that happens

**Suggested squash and merge commit message**
```
* Apply Black to codebase to revise docstring whitespace
   - Black v21.4b0 release notes: Black now processes one-line docstrings by stripping leading and trailing spaces, and adding a padding space when needed to break up “”””
* Add missing import of unyt.unyt_array to usage docs
* Add missing write option to h5py.File call in usage docs
```