### PR TITLE
FEAT: implement unyt.unyt_quantity.from_string

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,6 +21,7 @@ Contributors
 * Kacper Kowalik <xarthisius.kk@gmail.com>
 * Nathan Musoke <nathan.musoke@gmail.com>
 * Andrew Myers <atmyers2@gmail.com>
+* Clément Robert
 * Simon Schopferer <simon.schopferer@dlr.de>
 * Sam Skillman <samskillman@gmail.com>
 * Britton Smith <brittonsmith@gmail.com>

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -827,6 +827,25 @@ method:
   <Quantity([1 2 3], 'centimeter')>
 
 
+Reading quantities from text
+----------------------------
+
+Quantities can also be parsed from strings with the :func:`unyt_quantity.from_string <unyt.unyt_quantity.from_string>` function:
+
+  >>> from unyt import unyt_quantity
+  >>> unyt_quantity.from_string("1 cm")
+  unyt_quantity(1., 'cm')
+  >>> unyt_quantity.from_string("1e3 Msun")
+  unyt_quantity(1000., 'Msun')
+  >>> unyt_quantity.from_string("1e-3 g/cm**3")
+  unyt_quantity(0.001, 'g/cm**3')
+
+This method is helpful to read data from text files, for instance configuration
+files. It is intended to be as flexible as possible on the string format, though
+it requires that the numerical value and the unit name be separated with some
+kind of whitespace.
+
+
 User-Defined Units
 ++++++++++++++++++
 

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1366,8 +1366,10 @@ class unyt_array(np.ndarray):
         unyt_quantity(1., 'g/cm**3')
         """
         v = s.strip()
-        if re.fullmatch(_NUMB_PATTERN, v):
-            return float(re.match(_NUMB_PATTERN, v).group()) * Unit()
+        if re.fullmatch(_NUMB_REGEXP, v):
+            return float(re.match(_NUMB_REGEXP, v).group()) * Unit()
+        if re.fullmatch(_UNIT_REGEXP, v):
+            return 1 * Unit(re.match(_UNIT_REGEXP, v).group())
         if not re.match(_QUAN_REGEXP, v):
             raise ValueError("Received invalid quantity expression '{}'.".format(s))
         res = re.search(_NUMB_REGEXP, v)

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -17,6 +17,7 @@ import copy
 
 from functools import lru_cache
 from numbers import Number as numeric_type
+import re
 import numpy as np
 from numpy import (
     add,
@@ -144,6 +145,17 @@ __doctest_requires__ = {
     ("unyt_array.from_pint", "unyt_array.to_pint"): ["pint"],
     ("unyt_array.from_astropy", "unyt_array.to_astropy"): ["astropy"],
 }
+
+# This is partially adapted from the following SO thread
+# https://stackoverflow.com/questions/41668588/regex-to-match-scientific-notation
+_NUMB_PATTERN = r"^[+/-]?((?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)|\d*\.?\d+|\d+\.?\d*|nan\s|inf\s)"  # noqa: E501
+# *all* greek letters are considered valid unit string elements.
+# This may be an overshoot. We rely on unyt.Unit to do the actual validation
+_UNIT_PATTERN = r"([α-ωΑ-Ωa-zA-Z]+(\*\*([+/-]?[0-9]+)|[*/])?)+"
+_QUAN_PATTERN = r"{}\s*{}".format(_NUMB_PATTERN, _UNIT_PATTERN)
+_NUMB_REGEXP = re.compile(_NUMB_PATTERN)
+_UNIT_REGEXP = re.compile(_UNIT_PATTERN)
+_QUAN_REGEXP = re.compile(_QUAN_PATTERN)
 
 
 def _iterable(obj):
@@ -1204,8 +1216,8 @@ class unyt_array(np.ndarray):
         ----------
         arr : AstroPy Quantity
             The Quantity to convert from.
-        unit_registry : yt UnitRegistry, optional
-            A yt unit registry to use in the conversion. If one is not
+        unit_registry : unyt.UnitRegistry, optional
+            A unyt unit registry to use in the conversion. If one is not
             supplied, the default one will be used.
 
         Example
@@ -1262,8 +1274,8 @@ class unyt_array(np.ndarray):
         ----------
         arr : Pint Quantity
             The Quantity to convert from.
-        unit_registry : yt UnitRegistry, optional
-            A yt unit registry to use in the conversion. If one is not
+        unit_registry : unyt.UnitRegistry, optional
+            A unyt unit registry to use in the conversion. If one is not
             supplied, the default one will be used.
 
         Examples
@@ -1300,7 +1312,7 @@ class unyt_array(np.ndarray):
         unit_registry : Pint UnitRegistry, optional
             The Pint UnitRegistry to use in the conversion. If one is not
             supplied, the default one will be used. NOTE: This is not
-            the same as a yt UnitRegistry object.
+            the same as a unyt.UnitRegistry object.
 
         Examples
         --------
@@ -1323,6 +1335,50 @@ class unyt_array(np.ndarray):
             units.append("%s**(%s)" % (unit, Rational(pow)))
         units = "*".join(units)
         return unit_registry.Quantity(self.value, units)
+
+    @staticmethod
+    def from_string(s, unit_registry=None):
+        """
+        Parse a string to a unyt_quantity object.
+
+        Parameters
+        ----------
+        s: str
+           A string representing a single quantity.
+        unit_registry: unyt.UnitRegistry, optional
+            A unyt unit registry to use in the conversion. If one is not
+            supplied, the default one will be used.
+
+        Examples
+        --------
+        >>> from unyt import unyt_quantity
+        >>> unyt_quantity.from_string("1cm")
+        unyt_quantity(1., 'cm')
+        >>> unyt_quantity.from_string("+1e3 Mearth")
+        unyt_quantity(1000., 'Mearth')
+        >>> unyt_quantity.from_string("-10. kg")
+        unyt_quantity(-10., 'kg')
+        >>> unyt_quantity.from_string(".66\tum")
+        unyt_quantity(0.66, 'μm')
+        >>> unyt_quantity.from_string("42")
+        unyt_quantity(42., '(dimensionless)')
+        >>> unyt_quantity.from_string("1.0 g/cm**3")
+        unyt_quantity(1., 'g/cm**3')
+        """
+        v = s.strip()
+        if re.fullmatch(_NUMB_PATTERN, v):
+            return float(re.match(_NUMB_PATTERN, v).group()) * Unit()
+        if not re.match(_QUAN_REGEXP, v):
+            raise ValueError("Received invalid quantity expression '{}'.".format(s))
+        res = re.search(_NUMB_REGEXP, v)
+        num = res.group()
+        res = re.search(_UNIT_REGEXP, v[res.span()[1] :])
+        unit = res.group()
+        return float(num) * Unit(unit, registry=unit_registry)
+
+    def to_string(self):
+        # this is implemented purely for symmetry's sake
+        return str(self)
 
     #
     # End unit conversion methods

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -2494,6 +2494,7 @@ def test_string_formatting():
         ("+inf g", float("inf") * Unit("g")),
         ("-inf g", -float("inf") * Unit("g")),
         ("1", 1.0 * Unit()),
+        ("g", 1.0 * Unit("g")),
     ],
 )
 def test_valid_quantity_from_string(s, expected):
@@ -2509,7 +2510,6 @@ def test_valid_quantity_from_string(s, expected):
     [
         "++1cm",
         "--1cm",
-        "infcm",  # space sep is required here
         "cm10",
         "cm 10.",
         ".cm",
@@ -2526,13 +2526,14 @@ def test_invalid_expression_quantity_from_string(s):
         "10 cmmmm",
         "50. Km",
         ".6   MSUN",
+        "infcm",  # space sep is required here
     ],
 )
 def test_invalid_unit_quantity_from_string(s):
     # using a lazy solution here
     # this test would need to be refactored if we want to add other cases
     # without a space separator between number and unit.
-    un_str = s.split()[1]
+    un_str = s.split()[-1]
     with pytest.raises(
         UnitParseError,
         match="Could not find unit symbol '{}' in the provided symbols.".format(un_str),


### PR DESCRIPTION
This adds a from_string method to the unyt_quantity class. I originally wrote it in a separate project where I need to parse quantities from configuration (text) files, then realized it would be useful to have it as part of the library.

I consider this a draft for now. The implementation works as intended in every case I could think of (valid as well as invalid ones), but I would like to add doc strings (w/ doctests) to the actual function.