### PR TITLE
BUG: fix unit conversion for array with dtype int8

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -653,6 +653,12 @@ class unyt_array(np.ndarray):
                 # form, it's possible this may lose precision for very
                 # large integers
                 dsize = values.dtype.itemsize
+                if dsize == 1:
+                    raise ValueError(
+                        "Can't convert memory buffer in place. "
+                        f"Input dtype ({self.dtype}) has a smaller itemsize than the "
+                        "smallest floating point representation possible."
+                    )
                 new_dtype = "f" + str(dsize)
                 large = LARGE_INPUT.get(dsize, 0)
                 if large and np.any(np.abs(values) > large):
@@ -833,7 +839,7 @@ class unyt_array(np.ndarray):
                 (conversion_factor, offset) = self.units.get_conversion_factor(
                     new_units, self.dtype
                 )
-            dsize = self.dtype.itemsize
+            dsize = max(2, self.dtype.itemsize)
             if self.dtype.kind in ("u", "i"):
                 large = LARGE_INPUT.get(dsize, 0)
                 if large and np.any(np.abs(self.d) > large):

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -719,7 +719,7 @@ class unyt_array(np.ndarray):
         self.convert_to_units(
             self.units.get_base_equivalent(unit_system),
             equivalence=equivalence,
-            **kwargs
+            **kwargs,
         )
 
     def convert_to_cgs(self, equivalence=None, **kwargs):

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -746,6 +746,17 @@ def test_temperature_conversions():
     assert_array_almost_equal(balmy.in_cgs(), unyt_quantity(300, "K"))
 
 
+@pytest.mark.parametrize("itemsize", (8, 16, 32, 64))
+def test_conversion_from_int_types(itemsize):
+    a = unyt_array([1], "cm", dtype=f"int{itemsize}")
+
+    # check copy conversion
+    a.in_units("m")
+
+    # check in place conversion
+    a.convert_to_units("m")
+
+
 def test_unyt_array_unyt_quantity_ops():
     """
     Test operations that combine unyt_array and unyt_quantity


### PR DESCRIPTION
This dtype was apparently overlooked in PR #56

```python
import unyt as u
a = u.unyt_array(1, "cm", dtype="int8")
a.to("km") 
```
fails with
```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-fe344d50e9a4> in <module>
      1 import unyt as u
      2 a = u.unyt_array(1, "cm", dtype="int8")
----> 3 a.in_units("km")

~/dev/python/yt-project/unyt/unyt/array.py in in_units(self, units, equivalence, **kwargs)
    845                     )
    846             new_dtypekind = "c" if self.dtype.kind == "c" else "f"
--> 847             new_dtype = np.dtype(new_dtypekind + str(dsize))
    848             ret = np.asarray(self.ndview * conversion_factor, dtype=new_dtype)
    849             if offset:

TypeError: data type 'f1' not understood
```
the root cause is that `float8` dtype doesn't exist. The fix is to force minimal `itemsize` in bytes to 2, rather than copying it directly from the input dtype, so input array with dtype `int8` gets converted to `float16`.

While I'm at it I also patched `unyt_array.convert_to_units` so that it raises a clearer error message in case the user attempts to convert a `int8` array in place (which isn't possible, I think)