### PR TITLE
ENH: optimize import time

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ release = unyt.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -57,7 +57,7 @@ from unyt.exceptions import (
     UnitParseError,
     UnitsNotReducible,
 )
-from unyt.unit_registry import UnitRegistry, _lookup_unit_symbol, default_unit_registry
+from unyt.unit_registry import _lookup_unit_symbol, default_unit_registry
 from unyt.unit_systems import _split_prefix
 
 sympy_one = sympify(1)
@@ -517,8 +517,7 @@ class Unit:
         base_value = copy.deepcopy(self.base_value)
         base_offset = copy.deepcopy(self.base_offset)
         dimensions = copy.deepcopy(self.dimensions)
-        lut = copy.deepcopy(self.registry.lut)
-        registry = UnitRegistry(lut=lut)
+        registry = copy.deepcopy(self.registry)
         return Unit(expr, base_value, base_offset, dimensions, registry)
 
     #

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -509,16 +509,19 @@ class Unit:
         # fall back to expensive sympy comparison
         return self.dimensions != u.dimensions
 
-    def copy(self):
-        return copy.deepcopy(self)
-
-    def __deepcopy__(self, memodict=None):
+    def copy(self, *, deep=False):
         expr = str(self.expr)
         base_value = copy.deepcopy(self.base_value)
         base_offset = copy.deepcopy(self.base_offset)
         dimensions = copy.deepcopy(self.dimensions)
-        registry = copy.deepcopy(self.registry)
+        if deep:
+            registry = copy.deepcopy(self.registry)
+        else:
+            registry = copy.copy(self.registry)
         return Unit(expr, base_value, base_offset, dimensions, registry)
+
+    def __deepcopy__(self, memodict=None):
+        return self.copy(deep=True)
 
     #
     # End unit operations

--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -13,6 +13,7 @@ A registry for units that can be added to and modified.
 # -----------------------------------------------------------------------------
 
 
+import copy
 import json
 from functools import lru_cache
 from hashlib import md5
@@ -270,6 +271,10 @@ class UnitRegistry:
         equiv = [k for k, v in self.lut.items() if v[1] is unit_object.dimensions]
         equiv = list(sorted(set(equiv)))
         return equiv
+
+    def __deepcopy__(self, memodict=None):
+        lut = copy.deepcopy(self.lut)
+        return type(self)(lut=lut)
 
 
 #: The default unit registry


### PR DESCRIPTION
This is an answer to #27. I shave off about 33% of unyt's import time by making Unit objects copies shallow by default, the one difference with a deep copy being that the attached UnitRegistry is shallow-copied.

Using the benchmark I described in #27, I get the import time from 1.6s to 1.0s on my machine.
I hope that this doesn't have undesirable side effects.
Another aspect that could be considered is that the sheer number of copies that are performed at import time is probably a sign that something else isn't optimized.