### PR TITLE
support coercing iterables with nonuniform dimensionally equivalent units to a single unyt_array

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -257,7 +257,13 @@ def _coerce_iterable_units(input_object, registry=None):
         if any([isinstance(o, unyt_array) for o in input_object]):
             ff = getattr(input_object[0], "units", NULL_UNIT)
             if any([ff != getattr(_, "units", NULL_UNIT) for _ in input_object]):
-                raise IterableUnitCoercionError(input_object)
+                ret = []
+                for datum in input_object:
+                    try:
+                        ret.append(datum.in_units(ff.units))
+                    except UnitConversionError:
+                        raise IterableUnitCoercionError(str(input_object))
+                return unyt_array(np.array(ret), ff, registry=registry)
             # This will create a copy of the data in the iterable.
             return unyt_array(np.array(input_object), ff, registry=registry)
     return np.asarray(input_object)

--- a/unyt/exceptions.py
+++ b/unyt/exceptions.py
@@ -161,15 +161,15 @@ class IterableUnitCoercionError(Exception):
     Example
     -------
 
-    >>> from unyt import km, cm, unyt_array
-    >>> data = [2*cm, 3*km]
+    >>> from unyt import g, cm, unyt_array
+    >>> data = [2*cm, 3*g]
     >>> unyt_array(data)\
   # doctest: +IGNORE_EXCEPTION_DETAIL +NORMALIZE_WHITESPACE
     Traceback (most recent call last):
     ...
     unyt.exceptions.IterableUnitCoercionError: Received a list or
     tuple of quantities with nonuniform units:
-    [unyt_quantity(2., 'cm'), unyt_quantity(3., 'km')]
+    [unyt_quantity(2., 'cm'), unyt_quantity(3., 'g')]
     """
 
     def __init__(self, quantity_list):

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -2161,17 +2161,21 @@ def test_ones_and_zeros_like():
 
 
 def test_coerce_iterable():
-    from unyt import cm, km
+    from unyt import cm, m, g
 
     a = unyt_array([1, 2, 3], "cm")
-    b = [1 * cm, 2 * km, 3 * cm]
+    b = [1 * cm, 2 * m, 3 * cm]
+    c = [1 * g, 2 * m, 3 * cm]
 
+    assert_equal(a + b, unyt_array([2, 202, 6], "cm"))
+    assert_equal(b + a, unyt_array([2, 202, 6], "cm"))
     with pytest.raises(IterableUnitCoercionError):
-        a + b
+        a + c
     with pytest.raises(IterableUnitCoercionError):
-        b + a
+        c + a
+    assert_equal(unyt_array(b), unyt_array([1, 200, 3], "cm"))
     with pytest.raises(IterableUnitCoercionError):
-        unyt_array(b)
+        unyt_array(c)
 
 
 def test_bypass_validation():


### PR DESCRIPTION
Fixes #210.

See the test I modified for a usage example.