### PR TITLE
Bugfix for `np.divide.reduce`

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -139,7 +139,7 @@ from unyt.unit_registry import (
 )
 
 NULL_UNIT = Unit()
-POWER_SIGN_MAPPING = {multiply: 1, divide: -1}
+POWER_MAPPING = {multiply: lambda x: x, divide: lambda x: 2 - x}
 
 __doctest_requires__ = {
     ("unyt_array.from_pint", "unyt_array.to_pint"): ["pint"],
@@ -1758,11 +1758,11 @@ class unyt_array(np.ndarray):
                 # a reduction of a multiply or divide corresponds to
                 # a repeated product which we implement as an exponent
                 mul = 1
-                power_sign = POWER_SIGN_MAPPING[ufunc]
+                power_map = POWER_MAPPING[ufunc]
                 if "axis" in kwargs and kwargs["axis"] is not None:
-                    unit = u ** (power_sign * inp.shape[kwargs["axis"]])
+                    unit = u ** (power_map(inp.shape[kwargs["axis"]]))
                 else:
-                    unit = u ** (power_sign * inp.size)
+                    unit = u ** (power_map(inp.size))
             else:
                 # get unit of result
                 mul, unit = self._ufunc_registry[ufunc](u)

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -390,10 +390,18 @@ def test_multiplication():
     operate_and_compare(a1, a3, np.multiply, answer)
     operate_and_compare(a3, a1, np.multiply, answer)
 
+    # With np.multiply.reduce
+    a = unyt_array([1.0, 2.0, 3.0], "cm")
+    answer = unyt_quantity(6.0, "cm**3")
+    assert_equal(np.multiply.reduce(a), answer)
+    a = unyt_array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], "cm")
+    answer = unyt_array([6.0, 120.0], "cm**3")
+    assert_equal(np.multiply.reduce(a, axis=1), answer)
+
 
 def test_division():
     """
-    Test multiplication of two unyt_arrays
+    Test division of two unyt_arrays
 
     """
 
@@ -477,6 +485,14 @@ def test_division():
     operate_and_compare(a3, a1, np.divide, answer2)
     operate_and_compare(a1, a3, np.divide, answer1)
     operate_and_compare(a3, a1, np.divide, answer2)
+
+    # With np.multiply.reduce
+    a = unyt_array([3.0, 2.0, 1.0], "cm")
+    answer = unyt_quantity(1.5, "cm**-1")
+    assert_equal(np.divide.reduce(a), answer)
+    a = unyt_array([[3.0, 2.0, 1.0], [6.0, 5.0, 4.0]], "cm")
+    answer = unyt_array([1.5, 0.3], "cm**-1")
+    assert_equal(np.divide.reduce(a, axis=1), answer)
 
 
 def test_power():


### PR DESCRIPTION
Simple fix to address #230. Replaced `POWER_SIGN_MAPPING` with `POWER_MAPPING` and had this return simple functions (`lambda`s) to compute the exponent instead of just giving the sign of the exponent, which was used in the previous incorrect implementation. Added some unit tests for `np.divide.reduce` (and `np.multiply.reduce` for good measure), these fail before changes and pass afterwards. Also ran `black` and committed the result before starting so I could start with a "clean" set of tests. The functional changes are in the other two commits.