### PR TITLE
ENH: Give the option to change the value of the solar metallicity

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -435,6 +435,50 @@ and :meth:`unyt_array.convert_to_mks <unyt.array.unyt_array.convert_to_mks>` met
 
 See below for details on CGS and MKS electromagnetic units.
 
+Metallicity Unit Conversions
+----------------------------
+
+In the astrophysical context, "metals" are all of the elements that have atomic
+numbers greater than 2, i.e. everything heavier than helium. The "solar metallicity"
+is the mass fraction of metals in the solar atmosphere, and is used in a variety
+of contexts. Often, the metallicity of other astrophysical objects is expressed
+in terms of the solar metallicity, given by the unit :math:`Z_\odot`. The default
+mass fraction corresponding to :math:`Z_\odot` in :mod:`unyt` is 0.01295, corresponding
+to the value used in the `Cloudy Code <https://gitlab.nublado.org/cloudy/cloudy/-/wikis/home>`_.
+Metal mass fractions (by definition dimensionless) can be converted to :math:`Z_\odot`
+(and vice versa):
+
+  >>> from unyt import dimensionless
+  >>> M_Z = 0.0259*dimensionless
+  >>> M_Z
+  unyt_quantity(0.0259, 'dimensionless')
+  >>> M_Z.convert_to_units("Z_sun")
+  >>> M_Z
+  unyt_quantity(2., 'Zsun')
+
+However, the value of this mass fraction conversion must be measured, and various
+estimates of it disagree somewhat. Different sub-disciplines of astronomy often
+use different estimates in the literature. :mod:`unyt` provides a way to change
+the value of this unit conversion to one of several typical values, using the
+:func:`change_solar_metallicity_value` function, which takes the name of a
+reference value (see below):
+
+  >>> import unyt
+  >>> value_ref = "angr"
+  >>> unyt.change_solar_metallicity_value(value_ref)
+  >>> M_Z = 1.0*unyt.Zsun
+  >>> M_Z.convert_to_units("dimensionless")
+  >>> M_Z
+
+The available values for ``value_ref`` are:
+
+* ``"cloudy"``: 0.01295, from `Cloudy 17.03 <https://gitlab.nublado.org/cloudy/cloudy/-/wikis/home>`_
+* ``"angr"``: 0.01937, from `Anders E. & Grevesse N. (1989, Geochimica et Cosmochimica Acta 53, 197) <https://ui.adsabs.harvard.edu/abs/1989GeCoA..53..197A/abstract>`_
+* ``"aspl"``: 0.01337, from `Asplund M., Grevesse N., Sauval A.J. & Scott P. (2009, ARAA, 47, 481) <https://ui.adsabs.harvard.edu/abs/2009ARA&A..47..481A/abstract>`_
+* ``"feld"``: 0.01909, from `Feldman U. (Physica Scripta, 46, 202) <https://ui.adsabs.harvard.edu/abs/1992PhyS...46..202F/abstract>`_
+* ``"lodd"``: 0.01321, from `Lodders, K (2003, ApJ 591, 1220) <https://ui.adsabs.harvard.edu/abs/2003ApJ...591.1220L/abstract>`_
+
+
 Other Unit Systems
 ------------------
 

--- a/unyt/__init__.py
+++ b/unyt/__init__.py
@@ -62,7 +62,11 @@ from unyt.array import (  # NOQA: F401
 )
 from unyt.dimensions import accepts, returns  # NOQA: F401
 from unyt.testing import assert_allclose_units  # NOQA: F401
-from unyt.unit_object import Unit, define_unit  # NOQA: F401
+from unyt.unit_object import (  # NOQA: F401
+    Unit,
+    change_solar_metallicity_value,
+    define_unit,
+)
 from unyt.unit_registry import UnitRegistry  # NOQA: F401
 from unyt.unit_systems import UnitSystem  # NOQA: F401
 

--- a/unyt/_physical_ratios.py
+++ b/unyt/_physical_ratios.py
@@ -23,6 +23,15 @@ mass_sun_kg = 1.98841586e30
 temp_sun_kelvin = 5870.0
 luminosity_sun_watts = 3.8270e26
 
+# metallicity options
+metallicity_sun_values = {
+    'angr': 0.01937,
+    'aspl': 0.01337,
+    'feld': 0.01909,
+    'lodd': 0.01321,
+    'cloudy': 0.01295
+}
+
 # Consistent with solar abundances used in Cloudy
 metallicity_sun = 0.01295
 

--- a/unyt/_physical_ratios.py
+++ b/unyt/_physical_ratios.py
@@ -25,11 +25,11 @@ luminosity_sun_watts = 3.8270e26
 
 # metallicity options
 metallicity_sun_values = {
-    'angr': 0.01937,
-    'aspl': 0.01337,
-    'feld': 0.01909,
-    'lodd': 0.01321,
-    'cloudy': 0.01295
+    "angr": 0.01937,
+    "aspl": 0.01337,
+    "feld": 0.01909,
+    "lodd": 0.01321,
+    "cloudy": 0.01295,
 }
 
 # Consistent with solar abundances used in Cloudy

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -1108,4 +1108,40 @@ def define_unit(
         setattr(unyt, symbol, u)
 
 
+def change_solar_metallicity_value(self, value_ref, registry=None):
+    """
+    A number of values for the solar metallicity are present
+    in the astronomical literature, and different groups may
+    use different values. This function changes the default
+    value of the solar metallicity for conversions between the
+    "Zsun" unit and the metal mass fraction.
+
+    Parameters
+    ----------
+    value_ref : string
+        The reference value for the solar metallicity. Options
+        are:
+
+        "cloudy": 0.01295, from Cloudy 17.03
+        "angr": 0.01937, from Anders E. & Grevesse N. (1989, Geochimica et
+            Cosmochimica Acta 53, 197)
+        "aspl": 0.01337, from Asplund M., Grevesse N., Sauval A.J. & Scott
+            P. (2009, ARAA, 47, 481)
+        "feld": 0.01909, from Feldman U. (Physica Scripta, 46, 202)
+        "lodd": 0.01321, from Lodders, K (2003, ApJ 591, 1220)
+
+        The default value in unyt is "cloudy".
+    registry : :class:`unyt.unit_registry.UnitRegistry` or None
+        The unit registry for which the metallicity value will be adjusted.
+        If None, then defaults to the global default unit registry.
+
+    """
+    from unyt._physical_ratios import metallicity_sun_values
+
+    if registry is None:
+        registry = default_unit_registry
+
+    registry.modify("Zsun", metallicity_sun_values[value_ref])
+
+
 NULL_UNIT = Unit()

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -1136,12 +1136,20 @@ def change_solar_metallicity_value(value_ref, registry=None):
         If None, then defaults to the global default unit registry.
 
     """
+    import unyt
     from unyt._physical_ratios import metallicity_sun_values
 
     if registry is None:
         registry = default_unit_registry
 
+    # modify the value with the updated one from the table
     registry.modify("Zsun", metallicity_sun_values[value_ref])
+
+    # Now we have to reset the top-level Unit object
+    if registry is default_unit_registry:
+        symbol = "Zsun"
+        u = Unit(symbol, registry=registry)
+        setattr(unyt, symbol, u)
 
 
 NULL_UNIT = Unit()

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -1108,7 +1108,7 @@ def define_unit(
         setattr(unyt, symbol, u)
 
 
-def change_solar_metallicity_value(self, value_ref, registry=None):
+def change_solar_metallicity_value(value_ref, registry=None):
     """
     A number of values for the solar metallicity are present
     in the astronomical literature, and different groups may

--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -228,30 +228,6 @@ class UnitRegistry:
 
         self.lut[symbol] = (float(base_value), new_dimensions) + self.lut[symbol][2:]
 
-    def change_solar_metallicity_value(self, value_ref):
-        """
-        A number of values for the solar metallicity are present
-        in the astronomical literature, and different groups may
-        use different values. This function changes the default
-        value of the solar metallicity for conversions between the
-        "Zsun" unit and the metal mass fraction. Options for the
-        *value_ref* argument are:
-
-        "angr": 0.01937, from Anders E. & Grevesse N. (1989, Geochimica et
-            Cosmochimica Acta 53, 197)
-        "aspl": 0.01337, from Asplund M., Grevesse N., Sauval A.J. & Scott
-            P. (2009, ARAA, 47, 481)
-        "feld": 0.01909, from Feldman U. (Physica Scripta, 46, 202)
-        "lodd": 0.01321, from Lodders, K (2003, ApJ 591, 1220)
-        "cloudy": 0.01295, from Cloudy 17.03
-
-        The default value in unyt is "cloudy".
-
-        """
-        from unyt._physical_ratios import metallicity_sun_values
-
-        self.modify("Zsun", metallicity_sun_values[value_ref])
-
     def keys(self):
         """
         Print out the units contained in the lookup table.

--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -246,8 +246,10 @@ class UnitRegistry:
         "cloudy": 0.01295, from Cloudy 17.03
 
         The default value in unyt is "cloudy".
+
         """
         from unyt._physical_ratios import metallicity_sun_values
+
         self.modify("Zsun", metallicity_sun_values[value_ref])
 
     def keys(self):

--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -228,9 +228,27 @@ class UnitRegistry:
 
         self.lut[symbol] = (float(base_value), new_dimensions) + self.lut[symbol][2:]
 
-    def change_solar_metallicity_table(self, table_name):
+    def change_solar_metallicity_value(self, value_ref):
+        """
+        A number of values for the solar metallicity are present
+        in the astronomical literature, and different groups may
+        use different values. This function changes the default
+        value of the solar metallicity for conversions between the
+        "Zsun" unit and the metal mass fraction. Options for the
+        *value_ref* argument are:
+
+        "angr": 0.01937, from Anders E. & Grevesse N. (1989, Geochimica et
+            Cosmochimica Acta 53, 197)
+        "aspl": 0.01337, from Asplund M., Grevesse N., Sauval A.J. & Scott
+            P. (2009, ARAA, 47, 481)
+        "feld": 0.01909, from Feldman U. (Physica Scripta, 46, 202)
+        "lodd": 0.01321, from Lodders, K (2003, ApJ 591, 1220)
+        "cloudy": 0.01295, from Cloudy 17.03
+
+        The default value in unyt is "cloudy".
+        """
         from unyt._physical_ratios import metallicity_sun_values
-        self.modify("Zsun", metallicity_sun_values[table_name])
+        self.modify("Zsun", metallicity_sun_values[value_ref])
 
     def keys(self):
         """

--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -228,6 +228,10 @@ class UnitRegistry:
 
         self.lut[symbol] = (float(base_value), new_dimensions) + self.lut[symbol][2:]
 
+    def change_solar_metallicity_table(self, table_name):
+        from unyt._physical_ratios import metallicity_sun_values
+        self.modify("Zsun", metallicity_sun_values[table_name])
+
     def keys(self):
         """
         Print out the units contained in the lookup table.


### PR DESCRIPTION
This PR implements a function that allows one to change the value of the solar metallicity conversion factor. The default will remain the same, consistent with cloudy. 

Forthcoming:

- [ ] docs
- [ ] tests