### PR TITLE
BUG: fix a regression where unyt_array.reshape wasn't wrapping numpy.ndarray.reshape correctly

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,7 +73,7 @@ release = unyt.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -2155,12 +2155,14 @@ class unyt_quantity(unyt_array):
     def __round__(self):
         return type(self)(round(float(self)), self.units)
 
-    def reshape(self, shape, order="C"):
+    def reshape(self, *shape, order="C"):
         # this is necessary to support some numpy operations
         # natively, like numpy.meshgrid, which internally performs
         # reshaping, e.g., arr.reshape(1, -1), which doesn't affect the size,
         # but does change the object's internal representation to a >0D array
         # see https://github.com/yt-project/unyt/issues/224
+        if len(shape) == 1:
+            shape = shape[0]
         if shape == () or shape is None:
             return super().reshape(shape, order=order)
         else:

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -2673,3 +2673,11 @@ def test_reshape_quantity_noop(shape):
     b = a.reshape(shape)
     assert b.shape == a.shape == ()
     assert type(b) is unyt_quantity
+
+
+def test_reshape_quantity_via_shape_tuple():
+    # this is necessary to support np.tile
+    a = unyt_quantity(1, "m")
+    b = a.reshape(-1, 1)
+    assert b.shape == (1, 1)
+    assert type(b) is unyt_array


### PR DESCRIPTION
Fix #241
The issue was that `numpy.ndarray.reshape` accepts an arbitrary number of (integer) positional arguments to represent the shape
The following calls should be equivalent

```python
a.reshape(1, 2)
a.reshpae((1, 2))
```

I added a test case