### PR TITLE
TST: unpin pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ setenv =
 recreate = true
 depends = begin
 deps =
-    pytest~=6.2.5  # see https://github.com/astropy/pytest-doctestplus/issues/170 (this is only necessary for Python 3.6)
+    pytest
     sympy
     numpy
     h5py


### PR DESCRIPTION
Cleanup. According to the comment I left there, this pin isn't necessary now that support for Python 3.6 was dropped.