### PR TITLE
Change rst directive in HISTORY to avoid twine error

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -298,7 +298,7 @@ you run into issues please let us know by `opening an issue on GitHub
   operations that combine distinct dimensionally equivalent units will cancel in
   many situations. For example
 
-  .. doctest::
+  .. code-block::
 
      >>> from unyt import kg, g
      >>> print((12 * kg) / (4 * g))


### PR DESCRIPTION
When trying to create the release for v2.9.0 and uploading the packages to pypi using twine, I get this error:

```
❯ twine upload dist/*
Uploading distributions to https://upload.pypi.org/legacy/
Uploading unyt-2.9.0-py2.py3-none-any.whl
100%|█████████████████████████████████████████| 147k/147k [00:01<00:00, 115kB/s]
Error during upload. Retry with the --verbose option for more details.
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.
```

Running `twine check` reveals the issue:

```
❯ twine check dist/*
Checking dist/unyt-2.9.0-py2.py3-none-any.whl: FAILED
  `long_description` has syntax errors in markup and would not be rendered on PyPI.
    line 403: Error: Unknown directive type "doctest".

    .. doctest::

       >>> from unyt import kg, g
       >>> print((12 * kg) / (4 * g))
       3000.0 dimensionless
  warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
Checking dist/unyt-2.9.0.tar.gz: FAILED
  `long_description` has syntax errors in markup and would not be rendered on PyPI.
    line 403: Error: Unknown directive type "doctest".

    .. doctest::

       >>> from unyt import kg, g
       >>> print((12 * kg) / (4 * g))
       3000.0 dimensionless
  warning: `long_description_content_type` missing. defaulting to `text/x-rst`.
```

Something must have changed on pypi since our last release, since this seems to have gone off without a hitch previously. A simple solution is to change the `doctest` directive to a `code-block`. 