### PR TITLE
BUG: fix inheritance in unyt_array.__pow__

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1713,10 +1713,9 @@ class unyt_array(np.ndarray):
         if p == 0.0:
             ret = self.ua
             ret.units = Unit("dimensionless")
+            return ret
         else:
-            ret = self.__array_ufunc__(power, "__call__", self, p)
-
-        return ret
+            return super().__pow__(p)
 
     #
     # Start operation methods

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1702,7 +1702,7 @@ class unyt_array(np.ndarray):
             pass
         return ret
 
-    def __pow__(self, p):
+    def __pow__(self, p, mod=None, /):
         """
         Power function, over-rides the ufunc as
         ``numpy`` passes the ``_ones_like`` ufunc for
@@ -1715,7 +1715,7 @@ class unyt_array(np.ndarray):
             ret.units = Unit("dimensionless")
             return ret
         else:
-            return super().__pow__(p)
+            return super().__pow__(p, mod)
 
     #
     # Start operation methods


### PR DESCRIPTION
This change is a solution to a downstream issue in yt:
https://github.com/yt-project/yt/issues/4023

it's a direct follow up to #204 

I'm not 100% sure it's the *right* solution, as I don't understand the original implementation using `__array_func__`, so maybe I'm just missing something, in which case the problem should be resolved on the yt side instead.

@JBorrow I know it's been a little while, any chance you could explain your initial implementation please ?
