### PR TITLE
ENH: implement lazy imports for optional dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ universal = 1
 test = pytest
 
 [tool:pytest]
-norecursedirs = benchmarks paper .*
+norecursedirs = benchmarks paper .* unyt/_mpl_array_converter
 
 [versioneer]
 VCS = git

--- a/unyt/__init__.py
+++ b/unyt/__init__.py
@@ -68,13 +68,6 @@ from unyt.unit_systems import UnitSystem  # NOQA: F401
 
 from ._version import get_versions
 
-try:
-    from unyt.mpl_interface import matplotlib_support  # NOQA: F401
-except ImportError:
-    pass
-else:
-    matplotlib_support = matplotlib_support()
-
 
 # function to only import quantities into this namespace
 # we go through the trouble of doing this instead of "import *"
@@ -107,3 +100,9 @@ def test():  # pragma: no cover
     import pytest
 
     pytest.main([os.path.dirname(os.path.abspath(__file__))])
+
+
+# isort: off
+from unyt.mpl_interface import matplotlib_support
+
+matplotlib_support = matplotlib_support()

--- a/unyt/_mpl_array_converter/__init__.py
+++ b/unyt/_mpl_array_converter/__init__.py
@@ -1,0 +1,145 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2020, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the LICENSE file, distributed with this software.
+# -----------------------------------------------------------------------------
+
+from weakref import WeakKeyDictionary
+
+from matplotlib.units import AxisInfo, ConversionInterface
+
+from unyt.array import unyt_array, unyt_quantity
+from unyt.unit_object import Unit
+
+
+class unyt_arrayConverter(ConversionInterface):
+    """Matplotlib interface for unyt_array"""
+
+    _instance = None
+    _labelstyle = "()"
+    _axisnames = WeakKeyDictionary()
+
+    # ensure that unyt_arrayConverter is a singleton
+    def __new__(cls):
+        if unyt_arrayConverter._instance is None:
+            unyt_arrayConverter._instance = super().__new__(cls)
+        return unyt_arrayConverter._instance
+
+    # When matplotlib first encounters a type in its units.registry, it will
+    # call default_units to obtain the units. Then it calls axisinfo to
+    # customize the axis - in our case, just set the label. Then matplotlib calls
+    # convert.
+
+    @staticmethod
+    def axisinfo(unit, axis):
+        """Set the axis label based on unit
+
+        Parameters
+        ----------
+
+        unit : Unit object, string, or tuple
+            This parameter comes from unyt_arrayConverter.default_units() or from
+            user code such as Axes.plot(), Axis.set_units(), etc. In user code, it
+            is possible to convert the plotted units by specifing the new unit as
+            a string, such as "ms", or as a tuple, such as ("J", "thermal")
+            following the call signature of unyt_array.convert_to_units().
+        axis : Axis object
+
+        Returns
+        -------
+
+        AxisInfo object with the label formatted as in-line math latex
+        """
+        if isinstance(unit, tuple):
+            unit = unit[0]
+        unit_obj = unit if isinstance(unit, Unit) else Unit(unit)
+        name = unyt_arrayConverter._axisnames.get(axis, "")
+        if unit_obj.is_dimensionless:
+            label = name
+        else:
+            name += " "
+            unit_str = unit_obj.latex_representation()
+            if unyt_arrayConverter._labelstyle == "[]":
+                label = name + "$\\left[" + unit_str + "\\right]$"
+            elif unyt_arrayConverter._labelstyle == "/":
+                axsym = "$q_{\\rm" + axis.axis_name + "}$"
+                name = axsym if name == " " else name
+                if "/" in unit_str:
+                    label = name + "$\\;/\\;\\left(" + unit_str + "\\right)$"
+                else:
+                    label = name + "$\\;/\\;" + unit_str + "$"
+            else:
+                label = name + "$\\left(" + unit_str + "\\right)$"
+        return AxisInfo(label=label.strip())
+
+    @staticmethod
+    def default_units(x, axis):
+        """Return the Unit object of the unyt_array x
+
+        Parameters
+        ----------
+
+        x : unyt_array
+        axis : Axis object
+
+        Returns
+        -------
+
+        Unit object
+        """
+        # In the case where the first matplotlib command is setting limits,
+        # x may be a tuple of length two (with the same units).
+        if isinstance(x, tuple):
+            name = getattr(x[0], "name", "")
+            units = x[0].units
+        else:
+            name = getattr(x, "name", "")
+            units = x.units
+
+        # maintain a mapping between Axis and name since Axis does not point to
+        # its underlying data and we want to propagate the name to the axis
+        # label in the subsequent call to axisinfo
+        unyt_arrayConverter._axisnames[axis] = name if name is not None else ""
+        return units
+
+    @staticmethod
+    def convert(value, unit, axis):
+        """Convert the units of value to unit
+
+        Parameters
+        ----------
+
+        value : unyt_array, unyt_quantity, or sequence there of
+        unit : Unit, string or tuple
+            This parameter comes from unyt_arrayConverter.default_units() or from
+            user code such as Axes.plot(), Axis.set_units(), etc. In user code, it
+            is possible to convert the plotted units by specifing the new unit as
+            a string, such as "ms", or as a tuple, such as ("J", "thermal")
+            following the call signature of unyt_array.convert_to_units().
+        axis : Axis object
+
+        Returns
+        -------
+
+        unyt_array
+
+        Raises
+        ------
+
+        UnitConversionError if unit does not have the same dimensions as value or
+        if we don't know how to convert value.
+        """
+        converted_value = value
+        if isinstance(unit, str) or isinstance(unit, Unit):
+            unit = (unit,)
+        if isinstance(value, (unyt_array, unyt_quantity)):
+            converted_value = value.to(*unit)
+        else:
+            value_type = type(value)
+            converted_value = []
+            for obj in value:
+                converted_value.append(obj.to(*unit))
+            converted_value = value_type(converted_value)
+        return converted_value

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1781,7 +1781,7 @@ class unyt_array(np.ndarray):
             i0 = inputs[0]
             i1 = inputs[1]
 
-            if _dask._available and isinstance(i1, _dask.array.core.Array):
+            if _dask.__is_available__ and isinstance(i1, _dask.array.core.Array):
                 # need to short circuit all this to handle binary operations
                 # like unyt_quantity(2,'m') / unyt_dask_array_instance
                 # only need to check the second argument as if the first arg

--- a/unyt/mpl_interface.py
+++ b/unyt/mpl_interface.py
@@ -17,202 +17,74 @@ manager.
 # -----------------------------------------------------------------------------
 
 
-try:
-    from matplotlib.units import AxisInfo, ConversionInterface, registry
-except ImportError:
-    pass
-else:
-    from weakref import WeakKeyDictionary
+from unyt.array import unyt_array, unyt_quantity
 
-    from unyt import Unit, unyt_array, unyt_quantity
+from ._on_demand_imports import _matplotlib
 
-    __all__ = ["matplotlib_support"]
+__all__ = ["matplotlib_support"]
 
-    class unyt_arrayConverter(ConversionInterface):
-        """Matplotlib interface for unyt_array"""
 
-        _instance = None
-        _labelstyle = "()"
-        _axisnames = WeakKeyDictionary()
+class matplotlib_support:
+    """Context manager for enabling the feature
 
-        # ensure that unyt_arrayConverter is a singleton
-        def __new__(cls):
-            if unyt_arrayConverter._instance is None:
-                unyt_arrayConverter._instance = super().__new__(cls)
-            return unyt_arrayConverter._instance
+    When used in a with statement, the feature is enabled during the context and
+    then disabled after it exits.
 
-        # When matplotlib first encounters a type in its units.registry, it will
-        # call default_units to obtain the units. Then it calls axisinfo to
-        # customize the axis - in our case, just set the label. Then matplotlib calls
-        # convert.
+    Parameters
+    ----------
 
-        @staticmethod
-        def axisinfo(unit, axis):
-            """Set the axis label based on unit
+    label_style : str
+        One of the following set, ``{'()', '[]', '/'}``. These choices
+        correspond to the following unit labels:
 
-            Parameters
-            ----------
+        * ``'()'`` -> ``'(unit)'``
+        * ``'[]'`` -> ``'[unit]'``
+        * ``'/'`` -> ``'q_x / unit'``
+    """
 
-            unit : Unit object, string, or tuple
-                This parameter comes from unyt_arrayConverter.default_units() or from
-                user code such as Axes.plot(), Axis.set_units(), etc. In user code, it
-                is possible to convert the plotted units by specifing the new unit as
-                a string, such as "ms", or as a tuple, such as ("J", "thermal")
-                following the call signature of unyt_array.convert_to_units().
-            axis : Axis object
+    @property
+    def array_converter(self):
+        from ._mpl_array_converter import unyt_arrayConverter
 
-            Returns
-            -------
+        unyt_arrayConverter._labelstyle = self.label_style
+        return unyt_arrayConverter
 
-            AxisInfo object with the label formatted as in-line math latex
-            """
-            if isinstance(unit, tuple):
-                unit = unit[0]
-            unit_obj = unit if isinstance(unit, Unit) else Unit(unit)
-            name = unyt_arrayConverter._axisnames.get(axis, "")
-            if unit_obj.is_dimensionless:
-                label = name
-            else:
-                name += " "
-                unit_str = unit_obj.latex_representation()
-                if unyt_arrayConverter._labelstyle == "[]":
-                    label = name + "$\\left[" + unit_str + "\\right]$"
-                elif unyt_arrayConverter._labelstyle == "/":
-                    axsym = "$q_{\\rm" + axis.axis_name + "}$"
-                    name = axsym if name == " " else name
-                    if "/" in unit_str:
-                        label = name + "$\\;/\\;\\left(" + unit_str + "\\right)$"
-                    else:
-                        label = name + "$\\;/\\;" + unit_str + "$"
-                else:
-                    label = name + "$\\left(" + unit_str + "\\right)$"
-            return AxisInfo(label=label.strip())
+    def __init__(self, label_style="()"):
+        self._labelstyle = label_style
+        self._enabled = False
 
-        @staticmethod
-        def default_units(x, axis):
-            """Return the Unit object of the unyt_array x
+    def __call__(self):
+        self.__enter__()
 
-            Parameters
-            ----------
-
-            x : unyt_array
-            axis : Axis object
-
-            Returns
-            -------
-
-            Unit object
-            """
-            # In the case where the first matplotlib command is setting limits,
-            # x may be a tuple of length two (with the same units).
-            if isinstance(x, tuple):
-                name = getattr(x[0], "name", "")
-                units = x[0].units
-            else:
-                name = getattr(x, "name", "")
-                units = x.units
-
-            # maintain a mapping between Axis and name since Axis does not point to
-            # its underlying data and we want to propagate the name to the axis
-            # label in the subsequent call to axisinfo
-            unyt_arrayConverter._axisnames[axis] = name if name is not None else ""
-            return units
-
-        @staticmethod
-        def convert(value, unit, axis):
-            """Convert the units of value to unit
-
-            Parameters
-            ----------
-
-            value : unyt_array, unyt_quantity, or sequence there of
-            unit : Unit, string or tuple
-                This parameter comes from unyt_arrayConverter.default_units() or from
-                user code such as Axes.plot(), Axis.set_units(), etc. In user code, it
-                is possible to convert the plotted units by specifing the new unit as
-                a string, such as "ms", or as a tuple, such as ("J", "thermal")
-                following the call signature of unyt_array.convert_to_units().
-            axis : Axis object
-
-            Returns
-            -------
-
-            unyt_array
-
-            Raises
-            ------
-
-            UnitConversionError if unit does not have the same dimensions as value or
-            if we don't know how to convert value.
-            """
-            converted_value = value
-            if isinstance(unit, str) or isinstance(unit, Unit):
-                unit = (unit,)
-            if isinstance(value, (unyt_array, unyt_quantity)):
-                converted_value = value.to(*unit)
-            else:
-                value_type = type(value)
-                converted_value = []
-                for obj in value:
-                    converted_value.append(obj.to(*unit))
-                converted_value = value_type(converted_value)
-            return converted_value
-
-    class matplotlib_support:
-        """Context manager for enabling the feature
-
-        When used in a with statement, the feature is enabled during the context and
-        then disabled after it exits.
-
-        Parameters
-        ----------
-
-        label_style : str
-          One of the following set, ``{'()', '[]', '/'}``. These choices
-          correspond to the following unit labels:
+    @property
+    def label_style(self):
+        """str: One of the following set, ``{'()', '[]', '/'}``.
+        These choices correspond to the following unit labels:
 
             * ``'()'`` -> ``'(unit)'``
             * ``'[]'`` -> ``'[unit]'``
             * ``'/'`` -> ``'q_x / unit'``
         """
+        return self._labelstyle
 
-        def __init__(self, label_style="()"):
-            self._labelstyle = label_style
-            unyt_arrayConverter._labelstyle = label_style
-            self._enabled = False
+    @label_style.setter
+    def label_style(self, label_style="()"):
+        self._labelstyle = label_style
+        self.array_converter._labelstyle = label_style
 
-        def __call__(self):
-            self.__enter__()
+    def __enter__(self):
+        _matplotlib.units.registry[unyt_array] = self.array_converter()
+        _matplotlib.units.registry[unyt_quantity] = self.array_converter()
+        self._enabled = True
 
-        @property
-        def label_style(self):
-            """str: One of the following set, ``{'()', '[]', '/'}``.
-            These choices correspond to the following unit labels:
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        _matplotlib.units.registry.pop(unyt_array)
+        _matplotlib.units.registry.pop(unyt_quantity)
+        self._enabled = False
 
-              * ``'()'`` -> ``'(unit)'``
-              * ``'[]'`` -> ``'[unit]'``
-              * ``'/'`` -> ``'q_x / unit'``
-            """
-            return self._labelstyle
+    def enable(self):
+        self.__enter__()
 
-        @label_style.setter
-        def label_style(self, label_style="()"):
-            self._labelstyle = label_style
-            unyt_arrayConverter._labelstyle = label_style
-
-        def __enter__(self):
-            registry[unyt_array] = unyt_arrayConverter()
-            registry[unyt_quantity] = unyt_arrayConverter()
-            self._enabled = True
-
-        def __exit__(self, exc_type, exc_val, exc_tb):
-            registry.pop(unyt_array)
-            registry.pop(unyt_quantity)
-            self._enabled = False
-
-        def enable(self):
-            self.__enter__()
-
-        def disable(self):
-            if self._enabled:
-                self.__exit__(None, None, None)
+    def disable(self):
+        if self._enabled:
+            self.__exit__(None, None, None)

--- a/unyt/tests/test_dask_arrays.py
+++ b/unyt/tests/test_dask_arrays.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_array_equal
 from unyt import unyt_array, unyt_quantity
 from unyt._on_demand_imports import _dask as dask
 
-if not dask._available:
+if not dask.__is_available__:
     pytest.skip("dask isn't installed", allow_module_level=True)
 
 from unyt.dask_array import (

--- a/unyt/tests/test_mpl_interface.py
+++ b/unyt/tests/test_mpl_interface.py
@@ -2,13 +2,12 @@
 import numpy as np
 import pytest
 
-from unyt import K, m, s, unyt_array, unyt_quantity
+from unyt import K, m, matplotlib_support, s, unyt_array, unyt_quantity
 from unyt._on_demand_imports import NotAModule, _matplotlib
 from unyt.exceptions import UnitConversionError
 
 try:
-    from unyt import matplotlib_support
-    from unyt.mpl_interface import unyt_arrayConverter
+    from unyt._mpl_array_converter import unyt_arrayConverter
 except ImportError:
     pass
 


### PR DESCRIPTION
This is another step to resolve #27
Overall, this gets us to a state where core dependencies (numpy + sympy) are responsible for at least 50-60 % of unyt's import time.

This refactor is similar to my work in yt https://github.com/yt-project/yt/pull/3935
It allows for optional dependencies to never be imported before they are actually requested by users, reducing unyt's own startup time when heavy optional dependencies are installed.

Making matplotlib a true "on-demand" import took a little more work, but now `import unyt` doesn't cause `matplotlib` to be imported too when available, reducing the startup time by about 15% to 25% with respect to unyt 2.9.2 (on my machine).
