### PR TITLE
ENH: reduce redundant definitions for aliased unit symbols

### DIFF
--- a/unyt/unit_symbols.py
+++ b/unyt/unit_symbols.py
@@ -26,8 +26,8 @@ from unyt._unit_lookup_table import name_alternatives as _name_alternatives
 from unyt.unit_object import Unit as _Unit
 from unyt.unit_registry import default_unit_registry as _registry
 
-_namespace = globals()
-
+_ns = globals()
 for _canonical_name, _alt_names in _name_alternatives.items():
+    _u = _Unit(_canonical_name, registry=_registry)
     for _alt_name in _alt_names:
-        _namespace[_alt_name] = _Unit(_canonical_name, registry=_registry)
+        _ns[_alt_name] = _u


### PR DESCRIPTION
Shaves an additional 5% off of unyt's import time (address #27).
However this might not be worth it because it's not strictly backward compatible: it makes aliased unit symbols actually point to a single object instead of several identical objects, and maybe that's undesirable somehow ?
Anyway I'll still submit this proposal since it doesn't seem to break any existing test.
