### PR TITLE
ENH: don't import from top level sympy namespace

### DIFF
--- a/unyt/_parsing.py
+++ b/unyt/_parsing.py
@@ -16,7 +16,10 @@ parsing utilities
 
 import token
 
-from sympy import Basic, Float, Integer, Rational, Symbol, sqrt
+from sympy.core.basic import Basic
+from sympy.core.numbers import Float, Integer, Rational
+from sympy.core.symbol import Symbol
+from sympy.functions.elementary.miscellaneous import sqrt
 from sympy.parsing.sympy_parser import auto_number, parse_expr, rationalize
 
 from unyt._unit_lookup_table import inv_name_alternatives

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -114,7 +114,7 @@ except ImportError:
     clip = None
 import warnings
 
-from sympy import Rational
+from sympy.core.numbers import Rational
 
 from unyt._on_demand_imports import _astropy, _pint
 from unyt._pint_conversions import convert_pint_units

--- a/unyt/dimensions.py
+++ b/unyt/dimensions.py
@@ -16,7 +16,9 @@ Dimensions of physical quantities
 from functools import wraps
 from itertools import chain
 
-from sympy import Rational, Symbol, sympify
+from sympy.core.numbers import Rational
+from sympy.core.symbol import Symbol
+from sympy.core.sympify import sympify
 
 #: mass
 mass = Symbol("(mass)", positive=True)

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -27,7 +27,7 @@ from numpy.testing import (
     assert_array_almost_equal_nulp,
     assert_equal,
 )
-from sympy import Symbol
+from sympy.core.symbol import Symbol
 
 import unyt.unit_symbols as unit_symbols
 from unyt._physical_ratios import (

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -20,22 +20,17 @@ from functools import lru_cache
 from numbers import Number as numeric_type
 
 import numpy as np
-from sympy import (
-    Add,
-    Basic,
-    Expr,
-    Float,
-    Mod,
-    Mul,
-    Number,
-    Pow,
-    Rational,
-    Symbol,
-    floor,
-    latex,
-    sympify,
-)
-from sympy.core.numbers import One
+from sympy.core.add import Add
+from sympy.core.basic import Basic
+from sympy.core.expr import Expr
+from sympy.core.mod import Mod
+from sympy.core.mul import Mul
+from sympy.core.numbers import Float, Number, One, Rational
+from sympy.core.power import Pow
+from sympy.core.symbol import Symbol
+from sympy.core.sympify import sympify
+from sympy.functions.elementary.integers import floor
+from sympy.printing.latex import latex
 
 import unyt.dimensions as dims
 from unyt._parsing import parse_unyt_expr

--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -18,7 +18,7 @@ import json
 from functools import lru_cache
 from hashlib import md5
 
-from sympy import sympify
+from sympy.core.sympify import sympify
 
 from unyt import dimensions as unyt_dims
 from unyt._unit_lookup_table import default_unit_symbol_lut, unit_prefixes


### PR DESCRIPTION
Sympy is a major contributor to unyt's import time.
By importing sympy elements from their respective modules, we should in principle be able to avoid importing the whole sympy namespace and reduce unyt's import time.
Currently this has no actual impact because of a seemingly circular import in sympy:

```python
from sympy.core.sympify import sympify
```
imports the whole `sympy` module as a side effect.
We also cannot nest these specific imports in functions because `sympify` is used at unyt's top level to define some important objects.
So, maybe there's room to improve the situation upstream. In the mean time, it doesn't hurt to make these imports as specific as possible here.