### PR TITLE
DOC: use absolute URL for yt logo (fix linking on PyPI page)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ unyt
 
 |
 
- .. image:: docs/_static/yt_logo_small.png
+ .. image:: https://raw.githubusercontent.com/yt-project/unyt/master/docs/_static/yt_logo_small.png
          :target: https://yt-project.org
          :alt: The yt Project
 


### PR DESCRIPTION
Right now the image link is broken on the PyPI page
![Screenshot 2022-07-19 at 15 12 46](https://user-images.githubusercontent.com/14075922/179758666-bd7959c4-5023-4844-a17a-8eb3620f935e.png)

This fixes it