### PR TITLE
Include .readthedocs.yml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,29 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+    os: ubuntu-20.04
+    tools:
+        python: "3.8"
+        # You can also specify other tool versions:
+        # nodejs: "16"
+        # rust: "1.55"
+        # golang: "1.17"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+    configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+    install:
+        - requirements: docs/requirements.txt


### PR DESCRIPTION
This file will be used by readthedocs.org to configure the documentation and will specifically allow us to set the python version used to build the docs. 