### PR TITLE
restore ability to run tests when dask isn't installed

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     setuptools
     matplotlib!=3.5.0
     docutils
-    dask[array,diagnostics]>=2021.04.1
+    dask[array,diagnostics]
 commands =
     pytest --cov=unyt --cov-append --doctest-modules --doctest-plus --doctest-rst --basetemp={envtmpdir} -W once
     coverage report --omit='.tox/*'
@@ -39,7 +39,7 @@ deps =
     coverage>=5.0
     pytest-cov
     pytest-doctestplus
-    dask[array,diagnostics]>=2021.04.1
+    dask[array,diagnostics]==2021.04.1
 commands =
     # don't do doctests on old numpy versions
     pytest --cov=unyt --cov-append --basetemp={envtmpdir} -W once
@@ -54,7 +54,6 @@ deps =
     coverage>=5.0
     pytest-cov
     pytest-doctestplus
-    dask[array,diagnostics]>=2021.04.1
 depends = begin
 commands =
     # don't do doctests in rst files due to lack of way to specify optional
@@ -72,7 +71,7 @@ deps =
     numpy
     sympy
     matplotlib!=3.5.0
-    dask[array,diagnostics]>=2021.04.1
+    dask[array,diagnostics]
 commands =
     make clean
     python -m sphinx -M html "." "_build" -W

--- a/unyt/dask_array.py
+++ b/unyt/dask_array.py
@@ -13,12 +13,15 @@ import unyt.array as ua
 from unyt._on_demand_imports import _dask as dask
 
 __doctest_requires__ = {
-    ("dask_array.unyt_from_dask"): ["dask"],
+    ("unyt_from_dask", "reduce_with_units", "unyt_dask_array.to_dask"): ["dask"],
 }
 
 
-_dask_Array = dask.array.core.Array
-_dask_finalize = dask.array.core.finalize
+if dask.__is_available__:
+    _dask_Array = dask.array.core.Array
+    _dask_finalize = dask.array.core.finalize
+else:
+    _dask_Array, _dask_finalize = object, None
 
 # the following attributes hang off of dask.array.core.Array and do not modify units
 _use_unary_decorator = {


### PR DESCRIPTION
Right now if you try to run the tests with `pytest --doctest-plus --doctest-modules` when dask isn't installed you will get an error:

```
_____________________ ERROR collecting unyt/dask_array.py ______________________
unyt/dask_array.py:20: in <module>
    _dask_Array = dask.array.core.Array
unyt/_on_demand_imports.py:32: in __getattr__
    raise self.error
E   ImportError: This functionality requires the dask package to be installed.
```

This is happening because pytest has discovered doctests in `unyt/dask_array.py` but that module imports stuff from dask at top-level so the test discovery is failing. To fix that we need to make those top-level imports have a fallback when dask isn't installed. We also need to tell pytest to skip the doctests in that file. There was code already to handle that, but it wasn't using the scoping that the `__doctest_requires__` feature of `pytest-doctestplus` requires correctly. It also didn't include all the doctests that needed to be skipped.

All of this wasn't being caught because `dask` was being installed for all of the `tox` jobs, including the one that tests a minimal set of dependencies. To fix the tests going forward I removed `dask` from that `tox` job. I also removed the unnecessary minimum version constraints on the other `tox` jobs and made it so that the job that tests the earliest supported versions of dependencies to use an exact version constraint.