### PR TITLE
make unyt_quantity.from_string parse ints

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -834,7 +834,7 @@ Quantities can also be parsed from strings with the :func:`unyt_quantity.from_st
 
   >>> from unyt import unyt_quantity
   >>> unyt_quantity.from_string("1 cm")
-  unyt_quantity(1., 'cm')
+  unyt_quantity(1, 'cm')
   >>> unyt_quantity.from_string("1e3 Msun")
   unyt_quantity(1000., 'Msun')
   >>> unyt_quantity.from_string("1e-3 g/cm**3")

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -149,7 +149,9 @@ __doctest_requires__ = {
 
 # This is partially adapted from the following SO thread
 # https://stackoverflow.com/questions/41668588/regex-to-match-scientific-notation
-_NUMB_PATTERN = r"^[+/-]?((?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)|\d*\.?\d+|\d+\.?\d*|nan\s|inf\s)"  # noqa: E501
+_NUMB_PATTERN = (
+    r"[+/-]?(?:((?:\d\.?\d*[Ee][+\-]?\d+)|(?:\d+\.\d*|\d*\.\d+))|\d+|inf\s|nan\s)"
+)
 # *all* greek letters are considered valid unit string elements.
 # This may be an overshoot. We rely on unyt.Unit to do the actual validation
 _UNIT_PATTERN = r"([α-ωΑ-Ωa-zA-Z]+(\*\*([+/-]?[0-9]+)|[*/])?)+"
@@ -1376,7 +1378,7 @@ class unyt_array(np.ndarray):
         --------
         >>> from unyt import unyt_quantity
         >>> unyt_quantity.from_string("1cm")
-        unyt_quantity(1., 'cm')
+        unyt_quantity(1, 'cm')
         >>> unyt_quantity.from_string("+1e3 Mearth")
         unyt_quantity(1000., 'Mearth')
         >>> unyt_quantity.from_string("-10. kg")
@@ -1384,22 +1386,29 @@ class unyt_array(np.ndarray):
         >>> unyt_quantity.from_string(".66\tum")
         unyt_quantity(0.66, 'μm')
         >>> unyt_quantity.from_string("42")
-        unyt_quantity(42., '(dimensionless)')
+        unyt_quantity(42, '(dimensionless)')
         >>> unyt_quantity.from_string("1.0 g/cm**3")
         unyt_quantity(1., 'g/cm**3')
         """
         v = s.strip()
         if re.fullmatch(_NUMB_REGEXP, v):
-            return float(re.match(_NUMB_REGEXP, v).group()) * Unit()
-        if re.fullmatch(_UNIT_REGEXP, v):
-            return 1 * Unit(re.match(_UNIT_REGEXP, v).group())
-        if not re.match(_QUAN_REGEXP, v):
+            num = re.match(_NUMB_REGEXP, v).group()
+            unit = Unit()
+        elif re.fullmatch(_UNIT_REGEXP, v):
+            num = 1
+            unit = Unit(re.match(_UNIT_REGEXP, v).group())
+        elif not re.match(_QUAN_REGEXP, v):
             raise ValueError(f"Received invalid quantity expression '{s}'.")
-        res = re.search(_NUMB_REGEXP, v)
-        num = res.group()
-        res = re.search(_UNIT_REGEXP, v[res.span()[1] :])
-        unit = res.group()
-        return float(num) * Unit(unit, registry=unit_registry)
+        else:
+            res = re.search(_NUMB_REGEXP, v)
+            num = res.group()
+            res = re.search(_UNIT_REGEXP, v[res.span()[1] :])
+            unit = res.group()
+        try:
+            num = int(num)
+        except ValueError:
+            num = float(num)
+        return num * Unit(unit, registry=unit_registry)
 
     def to_string(self):
         # this is implemented purely for symmetry's sake

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -2560,42 +2560,43 @@ def test_string_formatting():
 
 
 @pytest.mark.parametrize(
-    "s, expected",
+    "s, expected, normalized",
     [
-        ("+1cm", 1.0 * Unit("cm")),
-        ("1cm", 1.0 * Unit("cm")),
-        ("1.cm", 1.0 * Unit("cm")),
-        ("1.0 cm", 1.0 * Unit("cm")),
-        ("1.0\tcm", 1.0 * Unit("cm")),
-        ("1.0\t cm", 1.0 * Unit("cm")),
-        ("1.0  cm", 1.0 * Unit("cm")),
-        ("1.0\t\tcm", 1.0 * Unit("cm")),
-        ("10e-1cm", 1.0 * Unit("cm")),
-        ("10E-1cm", 1.0 * Unit("cm")),
-        ("+1cm", 1.0 * Unit("cm")),
-        ("1um", 1.0 * Unit("μm")),
-        ("1μm", 1.0 * Unit("μm")),
-        ("-5 Msun", -5.0 * Unit("Msun")),
-        ("1e3km", 1e3 * Unit("km")),
-        ("-1e3    km", -1e3 * Unit("km")),
-        ("1.0 g/cm**3", 1.0 * Unit("g/cm**3")),
-        ("1 g*cm**-3", 1.0 * Unit("g/cm**3")),
-        ("1.0 g*cm", 1.0 * Unit("g*cm")),
-        ("nan g", float("nan") * Unit("g")),
-        ("-nan g", float("nan") * Unit("g")),
-        ("inf g", float("inf") * Unit("g")),
-        ("+inf g", float("inf") * Unit("g")),
-        ("-inf g", -float("inf") * Unit("g")),
-        ("1", 1.0 * Unit()),
-        ("g", 1.0 * Unit("g")),
+        ("+1cm", 1.0 * Unit("cm"), "1 cm"),
+        ("1cm", 1.0 * Unit("cm"), "1 cm"),
+        ("1.cm", 1.0 * Unit("cm"), "1.0 cm"),
+        ("1.0 cm", 1.0 * Unit("cm"), "1.0 cm"),
+        ("1.0\tcm", 1.0 * Unit("cm"), "1.0 cm"),
+        ("1.0\t cm", 1.0 * Unit("cm"), "1.0 cm"),
+        ("1.0  cm", 1.0 * Unit("cm"), "1.0 cm"),
+        ("1.0\t\tcm", 1.0 * Unit("cm"), "1.0 cm"),
+        ("10e-1cm", 1.0 * Unit("cm"), "1.0 cm"),
+        ("10E-1cm", 1.0 * Unit("cm"), "1.0 cm"),
+        ("+1cm", 1.0 * Unit("cm"), "1 cm"),
+        ("1um", 1.0 * Unit("μm"), "1 μm"),
+        ("1μm", 1.0 * Unit("μm"), "1 μm"),
+        ("-5 Msun", -5.0 * Unit("Msun"), "-5 Msun"),
+        ("1e3km", 1e3 * Unit("km"), "1000.0 km"),
+        ("-1e3    km", -1e3 * Unit("km"), "-1000.0 km"),
+        ("1.0 g/cm**3", 1.0 * Unit("g/cm**3"), "1.0 g/cm**3"),
+        ("1 g*cm**-3", 1.0 * Unit("g/cm**3"), "1 g/cm**3"),
+        ("1.0 g*cm", 1.0 * Unit("g*cm"), "1.0 cm*g"),
+        ("nan g", float("nan") * Unit("g"), "nan g"),
+        ("-nan g", float("nan") * Unit("g"), "nan g"),
+        ("inf g", float("inf") * Unit("g"), "inf g"),
+        ("+inf g", float("inf") * Unit("g"), "inf g"),
+        ("-inf g", -float("inf") * Unit("g"), "-inf g"),
+        ("1", 1.0 * Unit(), "1 dimensionless"),
+        ("g", 1.0 * Unit("g"), "1 g"),
     ],
 )
-def test_valid_quantity_from_string(s, expected):
+def test_valid_quantity_from_string(s, expected, normalized):
     actual = unyt_quantity.from_string(s)
     if "nan" in s:
         assert actual != expected
     else:
         assert actual == expected
+    assert actual.to_string() == normalized
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Sorry for getting this out on a Friday night, no need to take a look at this immediately.

I noticed that `unyt_quantity.to_string` wasn't being tested, so I modified the `from_string` test to round-trip back to a string via `to_string`. In the process, I noticed that ints weren't being loaded as I expected them to. I think it's probably closer to what a user would naively expect if we don't convert everything to float.

Since this behavior was included in a release it's possible some downstream users are relying on it. That said, I don't immediately see how making this change would cause much breakage since numpy and unyt can mix ints and floats with no issues.

Finally, the regex originally used parses `1.` as `1`, not `1.0` (python parses `1.` as `1.0`). Until making this change that didn't matter since the parsed number would be cast to a float anyway. I fixed the parsing issue by using a different scientific notation regex. The old one could probably be fixed but I couldn't figure that out, happy to do it that way if someone who is better at regex squinting can suggest it.