### PR TITLE
Improve test coverage

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1701,10 +1701,7 @@ class unyt_array(np.ndarray):
         ret = super().__getitem__(item)
         if getattr(ret, "shape", None) == ():
             ret = unyt_quantity(ret, bypass_validation=True, name=self.name)
-        try:
             ret.units = self.units
-        except AttributeError:
-            pass
         return ret
 
     def __pow__(self, p, mod=None, /):

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -15,6 +15,7 @@ unyt_array class.
 
 import copy
 import re
+import warnings
 from functools import lru_cache
 from numbers import Number as numeric_type
 
@@ -107,8 +108,6 @@ from numpy import (
     trunc,
 )
 from numpy.core.umath import _ones_like, clip
-import warnings
-
 from sympy import Rational
 
 from unyt._on_demand_imports import _astropy, _dask, _pint

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -106,12 +106,7 @@ from numpy import (
     true_divide,
     trunc,
 )
-from numpy.core.umath import _ones_like
-
-try:
-    from numpy.core.umath import clip
-except ImportError:
-    clip = None
+from numpy.core.umath import _ones_like, clip
 import warnings
 
 from sympy import Rational

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1706,12 +1706,11 @@ class unyt_array(np.ndarray):
 
     def __pow__(self, p, mod=None, /):
         """
-        Power function, over-rides the ufunc as
-        ``numpy`` passes the ``_ones_like`` ufunc for
-        powers of zero (in some cases), which leads to an
-        incorrect unit calculation.
+        Power function
         """
-
+        # over-rides the ufunc as ``numpy`` passes the ``_ones_like`` ufunc for
+        # powers of zero (in some cases), which leads to an incorrect unit
+        # calculation.
         if p == 0.0:
             ret = self.ua
             ret.units = Unit("dimensionless")

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1934,10 +1934,7 @@ class unyt_array(np.ndarray):
                 for o, oa in zip(out, out_arr):
                     if o is None:
                         continue
-                    try:
-                        o.units = oa.units
-                    except AttributeError:
-                        o.units = Unit("", registry=self.units.registry)
+                    o.units = oa.units
         if mul == 1:
             return out_arr
         return mul * out_arr

--- a/unyt/dask_array.py
+++ b/unyt/dask_array.py
@@ -288,6 +288,12 @@ class unyt_dask_array(_dask_Array):
         wrapped_func = _post_ufunc(super().__array_ufunc__, unyt_result)
         return wrapped_func(numpy_ufunc, method, *inputs, **kwargs)
 
+    def __array_function__(self, func, types, args, kwargs):
+        args, unyt_result = _prep_ufunc(func, *args, extract_dask=True, **kwargs)
+        types = [type(i) for i in args]
+        wrapped_func = _post_ufunc(super().__array_function__, unyt_result)
+        return wrapped_func(func, types, args, kwargs)
+
     def __getitem__(self, index):
         return _unary_dask_decorator(super().__getitem__, self)(index)
 

--- a/unyt/dask_array.py
+++ b/unyt/dask_array.py
@@ -288,12 +288,6 @@ class unyt_dask_array(_dask_Array):
         wrapped_func = _post_ufunc(super().__array_ufunc__, unyt_result)
         return wrapped_func(numpy_ufunc, method, *inputs, **kwargs)
 
-    def __array_function__(self, func, types, args, kwargs):
-        args, unyt_result = _prep_ufunc(func, *args, extract_dask=True, **kwargs)
-        types = [type(i) for i in args]
-        wrapped_func = _post_ufunc(super().__array_function__, unyt_result)
-        return wrapped_func(func, types, args, kwargs)
-
     def __getitem__(self, index):
         return _unary_dask_decorator(super().__getitem__, self)(index)
 

--- a/unyt/tests/test_dask_arrays.py
+++ b/unyt/tests/test_dask_arrays.py
@@ -342,13 +342,10 @@ def test_dask_array_reductions(dask_func_str, actual, axis, check_nan):
 def test_bad_dask_array_reductions():
     x_da = unyt_from_dask(dask.array.ones((10, 10), chunks=(2, 2)), m)
 
-    def empty_func():
-        pass
-
     with pytest.raises(
         ValueError, match="could not deduce np equivalent of dask reduction"
     ):
-        reduce_with_units(empty_func, x_da).compute()
+        reduce_with_units(lambda: None, x_da).compute()
 
 
 def test_prod():

--- a/unyt/tests/test_mpl_interface.py
+++ b/unyt/tests/test_mpl_interface.py
@@ -4,7 +4,6 @@ import pytest
 
 from unyt import K, m, matplotlib_support, s, unyt_array, unyt_quantity
 from unyt._on_demand_imports import NotAModule, _matplotlib
-from unyt.exceptions import UnitConversionError
 
 try:
     from unyt._mpl_array_converter import unyt_arrayConverter
@@ -82,13 +81,7 @@ def test_conversionerror(ax):
     y = [3, 4, 5] * K
     ax.plot(x, y)
     ax.xaxis.callbacks.exception_handler = None
-    # Newer matplotlib versions catch our exception and raise a custom
-    # ConversionError exception
-    try:
-        error_type = _matplotlib.units.ConversionError
-    except AttributeError:
-        error_type = UnitConversionError
-    with pytest.raises(error_type):
+    with pytest.raises(_matplotlib.units.ConversionError):
         ax.xaxis.set_units("V")
 
 

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -80,6 +80,11 @@ def assert_isinstance(a, type):
     assert isinstance(a, type)
 
 
+def assert_array_equal_units(a, b):
+    assert_array_equal(a, b)
+    assert_equal(a.units, b.units)
+
+
 def test_addition():
     """
     Test addition of two unyt_arrays
@@ -526,8 +531,10 @@ def test_power():
         assert isinstance(err.unit1, Unit)
         assert isinstance(err.unit2, Unit)
 
-    assert_equal(cm_quant, unyt_quantity(1.0, "dimensionless"))
-    assert_equal(cm_quant, unyt_quantity(1.0, "dimensionless"))
+    # when the power is 0.0 numpy short-circuits via ones_like so we
+    # need to test the special handling for that case
+    assert_array_equal_units(cm_quant**0, unyt_quantity(1.0, "dimensionless"))
+    assert_array_equal_units(cm_arr**0, unyt_quantity(1.0, "dimensionless"))
 
 
 def test_comparisons():


### PR DESCRIPTION
This PR improves a few places where we were missing test coverage. There are only two areas where we don't have 100% test coverage after this, both of which are hard to test and I'm OK with not having test coverage there.

The fixes fall into two flavors:

* Removing unnecessary compatibility code for old versions of dependencies we no longer support
* Fixing places where new code that's been added in the past couple years didn't have test coverage, either by removing unnecessary code or fixing existing broken tests.

@chrishavlin one of the changes was to delete `unyt_dask_array.__array_function__` since none of the existing tests invoke that function. Can you confirm that my change is correct and `__array_function__` is never called by code outside of `unyt`? It could also be that the existing tests don't invoke the necessary preconditions for `__array_function__` to get called too.

I also noticed that the docstring for `unyt_array.__pow__` that @JBorrow added included a lot of implementation details that users probably don't care about, so I moved that content into a comment.