### PR TITLE
remove unnecessary version constraints for coverage in tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
     pint==0.9
     astropy==3.2.3
     matplotlib==3.2.0
-    coverage>=5.0
+    coverage
     pytest-cov
     pytest-doctestplus
     dask[array,diagnostics]==2021.04.1
@@ -51,7 +51,7 @@ deps =
     pytest
     sympy
     numpy
-    coverage>=5.0
+    coverage
     pytest-cov
     pytest-doctestplus
 depends = begin
@@ -87,7 +87,7 @@ commands =
 depends =
 skip_install = true
 deps =
-    coverage>=5.0
+    coverage
 
 [testenv:end]
 commands =
@@ -96,4 +96,4 @@ commands =
 skip_install = true
 depends = py{38,39,310}
 deps =
-    coverage>=5.0
+    coverage


### PR DESCRIPTION
Since the current version of coverage is greater than 5.0, these version constraints are unnecessary.