### PR TITLE
update black minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py36']
+target-version = ['py38']
 line-length = 88
 exclude = '''
 (


### PR DESCRIPTION
Update to match minimum currently supported python version. AFAICS this has no impact on black's formatting.