### PR TITLE
fix setuptools warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,9 @@ setup(
     package_data={"unyt": ["tests/data/old_json_registry.txt"]},
     keywords="unyt",
     name="unyt",
-    packages=find_packages(include=["unyt", "unyt.tests", "unyt.tests.data"]),
+    packages=find_packages(
+        include=["unyt", "unyt.tests", "unyt.tests.data", "unyt._mpl_array_converter"]
+    ),
     test_suite="tests",
     tests_require=test_requirements,
     python_requires=">=3.8",


### PR DESCRIPTION
This fixes a warning setuptools is printing on CI:

```
 /tmp/pip-build-env-s0dabqhd/overlay/lib/python3.8/site-packages/setuptools/command/build_py.py:202: SetuptoolsDeprecationWarning:     Installing 'unyt._mpl_array_converter' as data is deprecated, please list it in `packages`.
      !!


      ############################
      # Package would be ignored #
      ############################
      Python recognizes 'unyt._mpl_array_converter' as an importable package,
      but it is not listed in the `packages` configuration of setuptools.

      'unyt._mpl_array_converter' has been automatically added to the distribution only
      because it may contain data files, but this behavior is likely to change
      in future versions of setuptools (and therefore is considered deprecated).

      Please make sure that 'unyt._mpl_array_converter' is included as a package by using
      the `packages` configuration field or the proper discovery methods
      (for example by using `find_namespace_packages(...)`/`find_namespace:`
      instead of `find_packages(...)`/`find:`).

      You can read more about "package discovery" and "data files" on setuptools
      documentation page.


  !!

    check.warn(importable)
```