### PR TITLE
MNT: fixup pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
     autofix_prs: false
 
 exclude: "^(\
-|paper/.*.py\
+paper/.*.py\
 )"
 
 repos:


### PR DESCRIPTION
#284 broke pre-commit such that all files are now being excluded. This fixes that