### PR TITLE
TST: treat warnings as errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,8 @@ skip =  ["venv", "benchmarks"]
 [tool.setuptools_scm]
 write_to = "unyt/_version.py"
 version_scheme = "post-release"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ write_to = "unyt/_version.py"
 version_scheme = "post-release"
 
 [tool.pytest.ini_options]
+addopts = "--ignore=benchmarks --ignore=paper"
 filterwarnings = [
     "error",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ write_to = "unyt/_version.py"
 version_scheme = "post-release"
 
 [tool.pytest.ini_options]
-addopts = "--ignore=benchmarks --ignore=paper"
+addopts = "--ignore=benchmarks --ignore=paper --ignore=unyt/_mpl_array_converter"
 filterwarnings = [
     "error",
 ]


### PR DESCRIPTION
In order to make sure no uncontrolled warning (internal or upstream) is raised during tests.