### PR TITLE
make array functions with out arguments behave more similarly to ufuncs

### DIFF
--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -378,8 +378,8 @@ def test_dot_mixed_ndarray_unyt_array():
 
     assert isinstance(res, unyt_array)
     assert isinstance(out, unyt_array)
-    assert res.units == out.units == km
-    assert res is out
+    assert res.units == out.units == cm
+    assert np.shares_memory(res, out)
 
     # check this works with an ndarray as the first operand
     out = np.zeros((3, 3)) * km
@@ -387,8 +387,8 @@ def test_dot_mixed_ndarray_unyt_array():
 
     assert isinstance(res, unyt_array)
     assert isinstance(out, unyt_array)
-    assert res.units == out.units == km
-    assert res is out
+    assert res.units == out.units == cm
+    assert np.shares_memory(res, out)
 
 
 def test_invalid_dot_matrices():
@@ -398,14 +398,10 @@ def test_invalid_dot_matrices():
     b.shape = (3, 3)
 
     out = np.empty((3, 3), dtype=np.int_, order="C") * s**2
-    with pytest.raises(
-        TypeError,
-        match=re.escape(
-            "output array is not acceptable "
-            "(units 's**2' cannot be converted to 'cm*s')"
-        ),
-    ):
-        np.dot(a, b, out=out)
+    res = np.dot(a, b, out=out)
+
+    np.testing.assert_array_equal(res, out)
+    assert out.units == res.units == cm * s
 
 
 def test_vdot():


### PR DESCRIPTION
This proposes another change to how we handle `out` arguments, again to make the behavior more similar to the current behavior of ufuncs. To illustrate this, take a look at the following script:

```
In [1]: import unyt as u

In [2]: import numpy as np

In [3]: a = [1, 2, 3]*u.g

In [4]: b = [1, 2, 3]*u.kg

In [5]: c = np.zeros((3, 3))*u.W

In [6]: np.add(a, b, out=c)
Out[6]: 
unyt_array([[1001., 2002., 3003.],
            [1001., 2002., 3003.],
            [1001., 2002., 3003.]], 'g')

In [7]: print(c)
[[1001. 2002. 3003.]
 [1001. 2002. 3003.]
 [1001. 2002. 3003.]] g
```

From which we see that ufuncs overwrite the output units.

IMO this is preferable to the current behavior for e.g. np.dot, which will check if `out` has units, raise an error if the units aren't convertible, and convert the result to `out`'s units otherwise. We don't actually need to do all that conversion work. We also IMO don't need to raise an error unnecessarily if we can just do what the user is asking us to do and make `out` have the same data as the result of the operation.