### PR TITLE
TST: add Python 3.11 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
         # Test all on ubuntu, test ends on macos and windows
         include:
           - os: macos-latest
@@ -25,9 +29,9 @@ jobs:
           - os: windows-latest
             python-version: '3.8'
           - os: macos-latest
-            python-version: '3.10'
+            python-version: '3.11'
           - os: windows-latest
-            python-version: '3.10'
+            python-version: '3.11'
 
 
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-docs,begin,py38-dependencies,py38-versions,py{38,39,310},py38-unyt-module-test-function,end
+envlist = py38-docs,begin,py38-dependencies,py38-versions,py{38,39,310,311},py38-unyt-module-test-function,end
 isolated_build = True
 
 [gh-actions]
@@ -7,6 +7,7 @@ python =
     3.8: py38, py38-docs, py38-dependencies, py38-versions, py38-unyt-module-test-function
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 setenv =
@@ -92,6 +93,6 @@ commands =
     coverage report --omit='.tox/*'
     coverage html --omit='.tox/*'
 skip_install = true
-depends = py{38,39,310}
+depends = py{38,39,310,311}
 deps =
     coverage


### PR DESCRIPTION
Note that Python 3.11 is not yet available via pyenv, so I'm not updating dev docs for now.