### PR TITLE
BUG: (NEP 18) fix upstream instabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ write_to = "unyt/_version.py"
 version_scheme = "post-release"
 
 [tool.pytest.ini_options]
-addopts = "--ignore=benchmarks --ignore=paper --ignore=unyt/_mpl_array_converter"
+addopts = "--ignore=benchmarks --ignore=paper --ignore=unyt/_mpl_array_converter --color=yes"
 filterwarnings = [
     "error",
     "ignore:Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.:UserWarning",

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -106,63 +106,31 @@ def histogram(
     a,
     bins=10,
     range=None,
-    normed=None,
-    weights=None,
-    density=None,
+    *args,
+    **kwargs,
 ):
     range = _sanitize_range(range, units=[a.units])
     counts, bins = np.histogram._implementation(
-        a.view(np.ndarray),
-        bins=bins,
-        range=range,
-        normed=normed,
-        weights=weights,
-        density=density,
+        a.view(np.ndarray), bins, range, *args, **kwargs
     )
     return counts, bins * a.units
 
 
 @implements(np.histogram2d)
-def histogram2d(
-    x,
-    y,
-    bins=10,
-    range=None,
-    normed=None,
-    weights=None,
-    density=None,
-):
+def histogram2d(x, y, bins=10, range=None, *args, **kwargs):
     range = _sanitize_range(range, units=[x.units, y.units])
     counts, xbins, ybins = np.histogram2d._implementation(
-        x.view(np.ndarray),
-        y.view(np.ndarray),
-        bins=bins,
-        range=range,
-        normed=normed,
-        weights=weights,
-        density=density,
+        x.view(np.ndarray), y.view(np.ndarray), bins, range, *args, **kwargs
     )
     return counts, xbins * x.units, ybins * y.units
 
 
 @implements(np.histogramdd)
-def histogramdd(
-    sample,
-    bins=10,
-    range=None,
-    normed=None,
-    weights=None,
-    density=None,
-):
+def histogramdd(sample, bins=10, range=None, *args, **kwargs):
     units = [_.units for _ in sample]
     range = _sanitize_range(range, units=units)
     counts, bins = np.histogramdd._implementation(
-        [_.view(np.ndarray) for _ in sample],
-        bins=bins,
-        range=range,
-        normed=normed,
-        weights=weights,
-        density=density,
+        [_.view(np.ndarray) for _ in sample], bins, range, *args, **kwargs
     )
     return counts, tuple(_bin * u for _bin, u in zip(bins, units))
 

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -278,9 +278,9 @@ def get_wrapped_functions(*modules):
     wrapped_functions = {}
     for mod in modules:
         for name, f in mod.__dict__.items():
-            if f is np.printoptions:
-                continue
             if callable(f) and hasattr(f, "__wrapped__"):
+                if f is np.printoptions or f.__name__.startswith("_"):
+                    continue
                 wrapped_functions[mod.__name__ + "." + name] = f
     return dict(sorted(wrapped_functions.items()))
 


### PR DESCRIPTION
- fix #311
- fix another instability where a new (hidden) function `numpy._no_nep50_warning` wasn't whitelisted from NEP 19 completeness tests

I'm ran the bleeding-edge workflow on my fork to demonstrate that this works:
https://github.com/neutrinoceros/unyt/actions/runs/3360690325

While I'm at it I also switched on color logs for pytest, which I think make logs on GH more readable.
