### PR TITLE
Additional metallicity mass fraction conversions

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -435,6 +435,48 @@ and :meth:`unyt_array.convert_to_mks <unyt.array.unyt_array.convert_to_mks>` met
 
 See below for details on CGS and MKS electromagnetic units.
 
+Metallicity Unit Conversions
+----------------------------
+
+In the astrophysical context, "metals" are all of the elements that have atomic
+numbers greater than 2, i.e. everything heavier than helium. The "solar metallicity"
+is the mass fraction of metals in the solar atmosphere, and is used in a variety
+of contexts. Often, the metallicity of other astrophysical objects is expressed
+in terms of the solar metallicity, given by the unit :math:`Z_\odot`. The default
+mass fraction corresponding to :math:`Z_\odot` in :mod:`unyt` is 0.01295, corresponding
+to the value used in the `Cloudy Code <https://gitlab.nublado.org/cloudy/cloudy/-/wikis/home>`_.
+Metal mass fractions (by definition dimensionless) can be converted to :math:`Z_\odot`
+(and vice versa):
+
+  >>> from unyt import dimensionless
+  >>> M_Z = 0.0259*dimensionless
+  >>> M_Z
+  unyt_quantity(0.0259, 'dimensionless')
+  >>> M_Z.convert_to_units("Z_sun")
+  >>> M_Z
+  unyt_quantity(2., 'Zsun')
+
+However, the value of this mass fraction conversion must be measured, and various
+estimates of it disagree somewhat. Different sub-disciplines of astronomy often
+use different estimates in the literature. :mod:`unyt` provides other metallicity
+unit conversions to several typical values in use. The available units (and their
+mass fraction conversion factors) are:
+
+* ``"Zsun_angr"``: 0.01937, from `Anders E. & Grevesse N. (1989, Geochimica et Cosmochimica Acta 53, 197) <https://ui.adsabs.harvard.edu/abs/1989GeCoA..53..197A/abstract>`_
+* ``"Zsun_aspl"``: 0.01337, from `Asplund M., Grevesse N., Sauval A.J. & Scott P. (2009, ARAA, 47, 481) <https://ui.adsabs.harvard.edu/abs/2009ARA&A..47..481A/abstract>`_
+* ``"Zsun_feld"``: 0.01909, from `Feldman U. (Physica Scripta, 46, 202) <https://ui.adsabs.harvard.edu/abs/1992PhyS...46..202F/abstract>`_
+* ``"Zsun_lodd"``: 0.01321, from `Lodders, K (2003, ApJ 591, 1220) <https://ui.adsabs.harvard.edu/abs/2003ApJ...591.1220L/abstract>`_
+
+These can be used in the same way as above:
+
+  >>> from unyt import dimensionless
+  >>> M_Z = 0.0259*dimensionless
+  >>> M_Z
+  unyt_quantity(0.0259, 'dimensionless')
+  >>> M_Z.convert_to_units("Zsun_angr")
+  >>> M_Z
+  unyt_quantity(1.33711926, 'Zsun_angr')
+
 Other Unit Systems
 ------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -464,7 +464,7 @@ mass fraction conversion factors) are:
 
 * ``"Zsun_angr"``: 0.01937, from `Anders E. & Grevesse N. (1989, Geochimica et Cosmochimica Acta 53, 197) <https://ui.adsabs.harvard.edu/abs/1989GeCoA..53..197A/abstract>`_
 * ``"Zsun_aspl"``: 0.01337, from `Asplund M., Grevesse N., Sauval A.J. & Scott P. (2009, ARAA, 47, 481) <https://ui.adsabs.harvard.edu/abs/2009ARA&A..47..481A/abstract>`_
-* ``"Zsun_feld"``: 0.01909, from `Feldman U. (Physica Scripta, 46, 202) <https://ui.adsabs.harvard.edu/abs/1992PhyS...46..202F/abstract>`_
+* ``"Zsun_feld"``: 0.01909, from `Feldman U. (1992, Physica Scripta, 46, 202) <https://ui.adsabs.harvard.edu/abs/1992PhyS...46..202F/abstract>`_
 * ``"Zsun_lodd"``: 0.01321, from `Lodders, K (2003, ApJ 591, 1220) <https://ui.adsabs.harvard.edu/abs/2003ApJ...591.1220L/abstract>`_
 
 These can be used in the same way as above:

--- a/unyt/_physical_ratios.py
+++ b/unyt/_physical_ratios.py
@@ -25,10 +25,10 @@ luminosity_sun_watts = 3.8270e26
 
 # Solar abundances from various references
 metallicity_sun = 0.01295  # Cloudy 17.03
-metallicity_sun_angr = 0.01937  # Anders & Grevasse (1989)
-metallicity_sun_aspl = 0.01337
-metallicity_sun_feld = 0.01909
-metallicity_sun_lodd = 0.01321
+metallicity_sun_angr = 0.01937  # Anders & Grevesse (1989)
+metallicity_sun_aspl = 0.01337  # Asplund et al. (2009)
+metallicity_sun_feld = 0.01909  # Feldman (1992)
+metallicity_sun_lodd = 0.01321  # Lodders (2003)
 
 # Conversion Factors:  X au * mpc_per_au = Y mpc
 # length

--- a/unyt/_physical_ratios.py
+++ b/unyt/_physical_ratios.py
@@ -23,8 +23,12 @@ mass_sun_kg = 1.98841586e30
 temp_sun_kelvin = 5870.0
 luminosity_sun_watts = 3.8270e26
 
-# Consistent with solar abundances used in Cloudy
-metallicity_sun = 0.01295
+# Solar abundances from various references
+metallicity_sun = 0.01295  # Cloudy 17.03
+metallicity_sun_angr = 0.01937  # Anders & Grevasse (1989)
+metallicity_sun_aspl = 0.01337
+metallicity_sun_feld = 0.01909
+metallicity_sun_lodd = 0.01321
 
 # Conversion Factors:  X au * mpc_per_au = Y mpc
 # length

--- a/unyt/_unit_lookup_table.py
+++ b/unyt/_unit_lookup_table.py
@@ -56,6 +56,10 @@ from unyt._physical_ratios import (
     mass_uranus_kg,
     mass_venus_kg,
     metallicity_sun,
+    metallicity_sun_angr,
+    metallicity_sun_aspl,
+    metallicity_sun_feld,
+    metallicity_sun_lodd,
     mu_0,
     neper_per_bel,
     newton_mks,
@@ -308,6 +312,46 @@ default_unit_symbol_lut = OrderedDict(
         (
             "Zsun",
             (metallicity_sun, dimensions.dimensionless, 0.0, r"\rm{Z}_\odot", False),
+        ),
+        (
+            "Zsun_angr",
+            (
+                metallicity_sun_angr,
+                dimensions.dimensionless,
+                0.0,
+                r"\rm{Z}_\odot",
+                False,
+            ),
+        ),
+        (
+            "Zsun_aspl",
+            (
+                metallicity_sun_aspl,
+                dimensions.dimensionless,
+                0.0,
+                r"\rm{Z}_\odot",
+                False,
+            ),
+        ),
+        (
+            "Zsun_feld",
+            (
+                metallicity_sun_feld,
+                dimensions.dimensionless,
+                0.0,
+                r"\rm{Z}_\odot",
+                False,
+            ),
+        ),
+        (
+            "Zsun_lodd",
+            (
+                metallicity_sun_lodd,
+                dimensions.dimensionless,
+                0.0,
+                r"\rm{Z}_\odot",
+                False,
+            ),
         ),
         ("Mjup", (mass_jupiter_kg, dimensions.mass, 0.0, r"\rm{M}_{\rm{Jup}}", False)),
         ("Mearth", (mass_earth_kg, dimensions.mass, 0.0, r"\rm{M}_\oplus", False)),


### PR DESCRIPTION
This PR introduces several other common values for the solar metallicity found in the literature as new metallicity units, e.g. `"Zsun_angr"`, etc. 

The default mass fraction in `"Zsun"` is still the one from Cloudy and has not been touched. 

Explanatory documentation has been added.