### PR TITLE
 BLD: remove wheel from explicit build time requirements (not needed in Python>=3.8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
   "setuptools>=61.2",
   "setuptools_scm[toml]>=6.2",
-  "wheel"
 ]
 
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
context: explictly declaring `wheel` as a build-time dependency is not needed with `pip>=19.0`, and the oldest supported Python version is now 3.8.0, which ships with `pip==19.3.2`
