### PR TITLE
TST: pin tox<4.0 to workaround incompatibility with tox-pyenv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Tox and any other packages
         run: |
           python -m pip install --upgrade pip setuptools wheel setuptools_scm
-          python -m pip install tox tox-pyenv coverage
+          python -m pip install "tox<4.0" tox-pyenv coverage # see https://github.com/tox-dev/tox-pyenv/issues/21
       - name: Build Docs
         if: matrix.python-version == '3.8'
         run: tox -e py38-docs -vvv


### PR DESCRIPTION
This PR isn't meant to be merged. Rather, I intend to use it as a playground to discover bugs with the upcoming new major release of tox. Best case scenario nothing breaks and we can close this.