### PR TITLE
TST: fix a test to work on numpy 1.24

### DIFF
--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -1499,11 +1499,8 @@ def test_string_operations_raise_errors():
         a * "hello"
     with pytest.raises(IterableUnitCoercionError):
         a ** "hello"
-    if Version(np.__version__) < Version("1.24"):
-        with pytest.warns(FutureWarning):
-            assert a != "hello"
-    else:
-        assert (a != "hello").all()
+    with pytest.warns(FutureWarning):
+        assert a != "hello"
 
 
 def test_string_operations_raise_errors_quantity():


### PR DESCRIPTION
Follow up to #333, fix a test that fails with the newly released version of numpy (1.24)