### PR TITLE
ENH: avoid importing dask when possible

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -15,6 +15,7 @@ unyt_array class.
 
 import copy
 import re
+import sys
 import warnings
 from functools import lru_cache
 from numbers import Number as numeric_type
@@ -1800,7 +1801,7 @@ class unyt_array(np.ndarray):
             i0 = inputs[0]
             i1 = inputs[1]
 
-            if _dask.__is_available__ and isinstance(i1, _dask.array.core.Array):
+            if "dask" in sys.modules and isinstance(i1, _dask.array.core.Array):
                 # need to short circuit all this to handle binary operations
                 # like unyt_quantity(2,'m') / unyt_dask_array_instance
                 # only need to check the second argument as if the first arg


### PR DESCRIPTION
Calling `isinstance(i1, _dask.array.core.Array)` leads to importing dask if it's installed but not yet imported, but if it's not imported well, we don't need to check if i1 is a dask Array.
Changing this check to be more clever avoids forcing the import of dask (about as expensive as numpy) on `import yt.utilities.physical_constants` and avoids bloating yt's startup time.