### PR TITLE
TST: migrate from tox-pyenv to tox-gh-actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,19 +39,6 @@ jobs:
       - name: Install Tox and any other packages
         run: |
           python -m pip install --upgrade pip setuptools wheel setuptools_scm
-          python -m pip install "tox<4.0" tox-pyenv coverage # see https://github.com/tox-dev/tox-pyenv/issues/21
-      - name: Build Docs
-        if: matrix.python-version == '3.8'
-        run: tox -e py38-docs -vvv
-      - name: Run Minimal Dependency Build
-        if: matrix.python-version == '3.8'
-        run: tox -e py38-dependencies
-      - name: Run Minimal Dependency Version Build
-        if: matrix.python-version == '3.8'
-        run: tox -e py38-versions
-      - name: Run Main Build
-        # Run tox using the version of Python in `PATH`
-        run: tox -e py -vvv
-      - name: Run In-place Tests
-        if: matrix.python-version == '3.8'
-        run: tox -e py38-unyt-module-test-function
+          python -m pip install tox tox-gh-actions
+      - name: Test
+        run: tox -vvv

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -98,7 +98,7 @@ managing your python evironment using your operating system's package manager or
     $ pyenv install -s 3.8.13
     $ pyenv install -s 3.9.12
     $ pyenv install -s 3.10.4
-    $ pip install tox tox-pyenv
+    $ pip install tox
 
 4. Install your local copy into a virtualenv or conda environment. You can also
    use one of the python interpreters we installed using ``pyenv``::

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,12 @@
 envlist = py38-docs,begin,py38-dependencies,py38-versions,py{38,39,310},py38-unyt-module-test-function,end
 isolated_build = True
 
+[gh-actions]
+python =
+    3.8: py38, py38-docs, py38-dependencies, py38-versions, py38-unyt-module-test-function
+    3.9: py39
+    3.10: py310
+
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
@@ -66,7 +72,7 @@ commands =
     coverage report --omit='.tox/*'
 
 [testenv:py38-docs]
-whitelist_externals = make
+allowlist_externals = make
 changedir = docs
 deps =
     pytest


### PR DESCRIPTION
Since tox-pyenv looks unmaintained (no response from the maintainer in 3 weeks now), let's experiment with a candidate replacement.
Because this makes tox 4 usable in CI for the first time, this may require some tweaks.
I'd also need to make changes in the dev guide if this works.

