### PR TITLE
TST: cleanup redundant requirements in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,6 @@ deps =
     matplotlib!=3.5.0
     docutils
     dask[array,diagnostics]
-    setuptools_scm
 commands =
     pytest --cov=unyt --cov-append --doctest-modules --doctest-plus --doctest-rst --basetemp={envtmpdir}
     coverage report --omit='.tox/*'
@@ -42,7 +41,6 @@ deps =
     pytest-cov
     pytest-doctestplus
     dask[array,diagnostics]==2021.04.1
-    setuptools_scm
 commands =
     # don't do doctests on old numpy versions
     pytest --cov=unyt --cov-append --basetemp={envtmpdir}
@@ -57,7 +55,6 @@ deps =
     coverage[toml]
     pytest-cov
     pytest-doctestplus
-    setuptools_scm
 depends = begin
 commands =
     # don't do doctests in rst files due to lack of way to specify optional
@@ -75,7 +72,6 @@ deps =
     sympy
     matplotlib!=3.5.0
     dask[array,diagnostics]
-    setuptools_scm
 commands =
     make clean
     python -m sphinx -M html "." "_build" -W

--- a/tox.ini
+++ b/tox.ini
@@ -10,13 +10,10 @@ recreate = true
 depends = begin
 deps =
     pytest
-    sympy
-    numpy
     h5py
     pint
     astropy
     coverage[toml]>=5.0
-    packaging
     pytest-cov
     pytest-doctestplus
     setuptools
@@ -50,8 +47,6 @@ commands =
 deps =
     docutils
     pytest
-    sympy
-    numpy
     coverage[toml]
     pytest-cov
     pytest-doctestplus
@@ -68,8 +63,6 @@ changedir = docs
 deps =
     pytest
     sphinx
-    numpy
-    sympy
     matplotlib!=3.5.0
     dask[array,diagnostics]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ deps =
     coverage[toml]>=5.0
     pytest-cov
     pytest-doctestplus
-    setuptools
     matplotlib!=3.5.0
     docutils
     dask[array,diagnostics]


### PR DESCRIPTION
`setuptool_scm` is only a dependency at buildtime and is already specified in `pyproject.toml` so we don't need it in `tox.ini`
