### PR TITLE
ENH: make dask a hard requirement for unyt.dask_array

### DIFF
--- a/unyt/dask_array.py
+++ b/unyt/dask_array.py
@@ -5,15 +5,24 @@ a dask array class (unyt_dask_array) and helper functions for unyt.
 
 """
 
+import sys
 from functools import wraps
 
 import numpy as np
-import pytest
 
 import unyt.array as ua
 
-pytest.importorskip("dask")
-del pytest
+if "pytest" in sys.modules:
+    # should only happen if pytest is installed *and* already imported,
+    # so we can skip collecting doctests from this module when dask isn't installed
+    # while avoiding making pytest itself a hard dependency to this module.
+    # This check is constructed to work with direct invocation (pytest unyt)
+    # as well as through python -m pytest
+    import pytest
+
+    pytest.importorskip("dask")
+    del pytest
+
 from dask.array.core import Array as DaskArray, finalize as dask_finalize  # noqa: E402
 
 # the following attributes hang off of dask.array.core.Array and do not modify units

--- a/unyt/dask_array.py
+++ b/unyt/dask_array.py
@@ -328,6 +328,7 @@ class unyt_dask_array(DaskArray):
         >>> x = da.random.random((10000, 10000), chunks=(1000, 1000))
         >>> x_da = dask_array.unyt_from_dask(x, 'm')
         >>> x_da.to_dask()
+        ... # doctest: +NORMALIZE_WHITESPACE
         dask.array<random_sample, shape=(10000, 10000), dtype=float64,
              chunksize=(1000, 1000), chunktype=numpy.ndarray>
         """


### PR DESCRIPTION
`unyt.dask_array` itself isn't loaded with `import unyt` so this doesn't make `dask` a hard dependency to the whole package, just the one module that is already unusable without it.

I find this simple change helps with boostrapping type-checking in unyt (see #296) because `mypy` is (rightfully) confused by conditional inheritance as is currently implemented in `unyt_dask_array`.

Namely, this resolves the following warnings from mypy
```
unyt/dask_array.py:194: error: Variable "unyt.dask_array._dask_Array" is not valid as a type  [valid-type]
unyt/dask_array.py:194: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
unyt/dask_array.py: note: In class "unyt_dask_array":
unyt/dask_array.py:194: error: Invalid base class "_dask_Array"  [misc]
```

`unyt._on_demand_imports._dask` continues to be useful in `unyt_array.__array_ufunc__` so I'm not removing it.