### PR TITLE
TST: simplify test build (⏰ wait for #358)

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -33,7 +33,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python Dev Version
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.11-dev'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Tox and any other packages
         run: |
-          python -m pip install --upgrade pip setuptools wheel setuptools_scm
+          python -m pip install --upgrade pip
           python -m pip install tox tox-gh-actions
       - name: Test
         run: tox -vvv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Tox and any other packages

--- a/README.rst
+++ b/README.rst
@@ -10,10 +10,10 @@ unyt
         :target: https://anaconda.org/conda-forge/unyt
         :alt: conda-forge
 
-.. image:: https://github.com/yt-project/unyt/actions/workflows/ci.yml/badge.svg?branch=master
+.. image:: https://github.com/yt-project/unyt/actions/workflows/ci.yml/badge.svg?branch=main
         :target: https://github.com/yt-project/unyt/actions/workflows/ci.yml
 
-.. image:: https://github.com/yt-project/unyt/actions/workflows/bleeding-edge.yaml/badge.svg?branch=master
+.. image:: https://github.com/yt-project/unyt/actions/workflows/bleeding-edge.yaml/badge.svg?branch=main
         :target: https://github.com/yt-project/unyt/actions/workflows/bleeding-edge.yaml
 
 .. image:: https://readthedocs.org/projects/unyt/badge/?version=latest

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -15,6 +15,7 @@ import re
 import shutil
 import tempfile
 import warnings
+from importlib.metadata import version
 from pathlib import Path
 
 import numpy as np
@@ -64,6 +65,8 @@ from unyt.testing import (
 )
 from unyt.unit_registry import UnitRegistry
 from unyt.unit_symbols import cm, degree, g, m
+
+NUMPY_VERSION = Version(version("numpy"))
 
 
 def operate_and_compare(a, b, op, answer):
@@ -1489,7 +1492,25 @@ def test_string_operations_raise_errors():
         a * "hello"
     with pytest.raises(IterableUnitCoercionError):
         a ** "hello"
+
+
+@pytest.mark.skipif(
+    NUMPY_VERSION >= Version("1.25.0.dev0"),
+    reason="FuturWarning was promoted to ValueError in numpy 1.25",
+)
+def test_string_comparison_numpy_lt_1_25():
+    a = unyt_array([1, 2, 3], "g")
     with pytest.warns(FutureWarning):
+        assert a != "hello"
+
+
+@pytest.mark.skipif(
+    NUMPY_VERSION < Version("1.25.0.dev0"),
+    reason="FuturWarning was promoted to ValueError in numpy 1.25",
+)
+def test_string_comparison_numpy_ge_1_25():
+    a = unyt_array([1, 2, 3], "g")
+    with pytest.raises(ValueError):
         assert a != "hello"
 
 


### PR DESCRIPTION
- remove unused installed packaged
- upgrade setup-python GHA to get rid of warnings:
<img width="706" alt="Screenshot 2023-01-15 at 15 36 58" src="https://user-images.githubusercontent.com/14075922/212547123-418c84a2-886b-4072-9972-fcb3bc817268.png">


[context](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
