### PR TITLE
STY: migrate linting to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,33 +19,24 @@ repos:
     - id: check-executables-have-shebangs
     - id: check-yaml
     - id: check-toml
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-    - id: pyupgrade
-      args: [--py38-plus]
+
 -   repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:
     - id: black
--   repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-    - id: isort
-      name: isort
--   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-    - id: flake8
-      additional_dependencies: [
-        flake8-bugbear==22.7.1,
-        flake8-2020==1.6.1,
-      ]
+
 -   repo: https://github.com/adamchainz/blacken-docs
     rev: 1.13.0
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==23.1.0]
+
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.0.247
+  hooks:
+  - id: ruff
+    #args: [--fix]
+
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
   rev: v0.0.247
   hooks:
   - id: ruff
-    #args: [--fix]
+    args: [--fix]
 
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,11 +89,31 @@ exclude = '''
 )
 '''
 
+[tool.ruff]
+target-version = "py38" # https://github.com/charliermarsh/ruff/issues/2039
+exclude = [
+    ".*/",
+    "benchmarks/*.py",
+    "paper/*.py",
+    "*/_version.py",
+    "*/__init__.py",
+]
+ignore = [
+    "E501",
+    "B904",
+]
+select = [
+    "E",
+    "F",
+    "W",
+    "B",   # flake8-bugbear
+    "YTT", # flake8-2020
+    "I",   # isort
+    "UP",  # pyupgrade
+]
 
-[tool.isort]
-profile = "black"
-combine_as_imports = true
-skip =  ["venv", "benchmarks"]
+[tool.ruff.isort]
+combine-as-imports = true
 
 [tool.setuptools_scm]
 write_to = "unyt/_version.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,14 +12,3 @@ replace = version='{new_version}'
 [bumpversion:file:unyt/__init__.py]
 search = __version__ = '{current_version}'
 replace = __version__ = '{new_version}'
-
-[flake8]
-exclude = .*/,
-          benchmarks/*.py,
-          paper/*.py,
-	      */_version.py,
-	      */__init__.py,  # avoid spurious "unused import"
-max-line-length = 88
-ignore =
-    E203,
-    W503,

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -751,8 +751,8 @@ def choose(a, choices, out=None, *args, **kwargs):
     res = np.choose._implementation(
         a,
         [np.asarray(c) for c in choices],
-        out=out.view(np.ndarray),
         *args,
+        out=out.view(np.ndarray),
         **kwargs,
     )
     if getattr(out, "units", None) is not None:
@@ -867,8 +867,8 @@ def clip(a, a_min, a_max, out=None, *args, **kwargs):
             np.asarray(a),
             np.asarray(a_min),
             np.asarray(a_max),
-            out=out.view(np.ndarray),
             *args,
+            out=out.view(np.ndarray),
             **kwargs,
         )
         * a.units

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -2464,7 +2464,7 @@ def _get_binary_op_return_class(cls1, cls2):
     else:
         raise RuntimeError(
             "Undefined operation for a unyt_array subclass. "
-            "Received operand types (%s) and (%s)" % (cls1, cls2)
+            f"Received operand types ({cls1}) and ({cls2})"
         )
 
 

--- a/unyt/exceptions.py
+++ b/unyt/exceptions.py
@@ -37,11 +37,11 @@ class UnitOperationError(ValueError):
 
     def __str__(self):
         err = (
-            'The %s operator for unyt_arrays with units "%s" '
-            '(dimensions "%s") ' % (self.operation, self.unit1, self.unit1.dimensions)
+            f"The {self.operation} operator for unyt_arrays with units "
+            f"'{self.unit1}' (dimensions '{self.unit1.dimensions}')"
         )
         if self.unit2 is not None:
-            err += f'and "{self.unit2}" (dimensions "{self.unit2.dimensions}") '
+            err += f"and '{self.unit2}' (dimensions '{self.unit2.dimensions}') "
         err += "is not well defined."
         return err
 
@@ -95,11 +95,9 @@ class UnitConversionError(Exception):
         Exception.__init__(self)
 
     def __str__(self):
-        err = "Cannot convert between '%s' (dim '%s') and '%s' " "(dim '%s')." % (
-            self.unit1,
-            self.dimension1,
-            self.unit2,
-            self.dimension2,
+        err = (
+            f"Cannot convert between '{self.unit1}' (dim '{self.dimension1}') "
+            f"and '{self.unit2}' (dim '{self.dimension2}')."
         )
         return err
 

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -197,7 +197,7 @@ class Unit:
             if unit_expr.shape != ():
                 raise UnitParseError(
                     "Cannot create a unit from a non-scalar unyt_array, "
-                    "received: %s" % (unit_expr,)
+                    f"received: {unit_expr}"
                 )
             value = unit_expr.value
             if value == 1:
@@ -218,7 +218,7 @@ class Unit:
         if not isinstance(unit_expr, Expr):
             raise UnitParseError(
                 "Unit representation must be a string or "
-                "sympy Expr. '%s' has type '%s'." % (unit_expr, type(unit_expr))
+                f"sympy Expr. '{unit_expr}' has type '{type(unit_expr)}'."
             )
 
         if dimensions is None and unit_expr is sympy_one:
@@ -246,7 +246,7 @@ class Unit:
             except ValueError:
                 raise UnitParseError(
                     "Could not use base_value as a float. "
-                    "base_value is '%s' (type '%s')." % (base_value, type(base_value))
+                    f"base_value is '{base_value}' (type {type(base_value)})."
                 )
 
             # check that dimensions is valid
@@ -389,8 +389,8 @@ class Unit:
                 units = self
             if data.dtype.kind not in ("f", "u", "i", "c"):
                 raise InvalidUnitOperation(
-                    "Tried to multiply a Unit object with '%s' (type %s). "
-                    "This behavior is undefined." % (u, type(u))
+                    f"Tried to multiply a Unit object with '{u}' (type {type(u)}). "
+                    "This behavior is undefined."
                 )
             if data.shape == ():
                 return _import_cache_singleton.uq(data, units, bypass_validation=True)
@@ -429,8 +429,8 @@ class Unit:
                 return unyt_quantity(1.0, self) / u
             else:
                 raise InvalidUnitOperation(
-                    "Tried to divide a Unit object by '%s' (type %s). This "
-                    "behavior is undefined." % (u, type(u))
+                    f"Tried to divide a Unit object by '{u}' (type {type(u)}). "
+                    "This behavior is undefined."
                 )
         elif self.dimensions is logarithmic and not u.is_dimensionless:
             raise InvalidUnitOperation(f"Tried to divide '{self}' and '{u}'.")
@@ -464,9 +464,8 @@ class Unit:
             p = Rational(str(p)).limit_denominator()
         except (ValueError, TypeError):
             raise InvalidUnitOperation(
-                "Tried to take a Unit object to the "
-                "power '%s' (type %s). Failed to cast "
-                "it to a float." % (p, type(p))
+                f"Tried to take a Unit object to the power '{p}' (type {type(p)}). "
+                "Failed to cast it to a float."
             )
 
         if self.dimensions is logarithmic and p != 1.0:


### PR DESCRIPTION
Ruff reimplements a bunch of linters that we're already using in rust. The performance gain is nice but somewhat anecdotal for unyt.
The main reasons I'd like to propose this migration are:
- align unyt with other projects in the org (mainly yt)
- reduce the number of linting dependencies that we need to keep track of
- I just found 2 bugs (unreleased) with it (could have caught them with `flake8-bugbear` had it been up to date)
