### PR TITLE
MNT: enable dependabot autoupdates for GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /.github/workflows
+  schedule:
+    interval: monthly


### PR DESCRIPTION
automate workflow updates with dependabot.
see https://github.com/yt-project/yt/issues/4333 for why this is needed