### PR TITLE
ENH: avoid importing numpy.testing at startup

### DIFF
--- a/unyt/testing.py
+++ b/unyt/testing.py
@@ -6,8 +6,6 @@ Utilities for writing tests
 
 import warnings
 
-import numpy.testing as npt
-
 from unyt.array import NULL_UNIT, allclose_units
 
 
@@ -74,7 +72,9 @@ def assert_array_equal_units(x, y, **kwargs):
     function for details.
     """
     # see https://github.com/yt-project/unyt/issues/281
-    npt.assert_array_equal(x, y, **kwargs)
+    from numpy.testing import assert_array_equal
+
+    assert_array_equal(x, y, **kwargs)
     assert getattr(x, "units", NULL_UNIT) == getattr(y, "units", NULL_UNIT)
 
 


### PR DESCRIPTION
`import numpy.testing` adds about 4% overhead to unyt's startup time.

measured and visualised with the following command
```
python -X importtime -c "import unyt" 2> import.log && tuna import.log
```