### PR TITLE
MNT: clean redundant minimal supported version metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         additional_dependencies: [black==23.1.0]
 
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: v0.0.254
+  rev: v0.0.257
   hooks:
   - id: ruff
     args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,6 @@ exclude = '''
 '''
 
 [tool.ruff]
-target-version = "py38" # https://github.com/charliermarsh/ruff/issues/2039
 exclude = [
     ".*/",
     "benchmarks/*.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,6 @@ unyt = [
 
 
 [tool.black]
-target-version = ['py38']
-line-length = 88
 exclude = '''
 (
   /(


### PR DESCRIPTION
black recently gained the ability to infer minimal target versions from project metadata (`[project]:requires-python`) (see https://black.readthedocs.io/en/stable/change_log.html#id2)

as did `ruff` (see https://github.com/charliermarsh/ruff/pull/3470)

I'm also cleaning up `black`'s `line-length` option since its set to the default value.
