### PR TITLE
DEPR: expire deprecation for input_units argument

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -405,11 +405,11 @@ class unyt_array(np.ndarray):
 
     input_array : iterable
         A tuple, list, or array to attach units to
-    input_units : String unit name, unit symbol object, or astropy unit
+    units : String unit name, unit symbol object, or astropy unit
         The units of the array. Powers must be specified using python
         syntax (cm**3, not cm^3).
     registry : :class:`unyt.unit_registry.UnitRegistry`
-        The registry to create units from. If input_units is already associated
+        The registry to create units from. If units is already associated
         with a unit registry and this is specified, this will be used instead
         of the registry associated with the unit object.
     dtype : numpy dtype or dtype name
@@ -419,7 +419,7 @@ class unyt_array(np.ndarray):
         If True, all input validation is skipped. Using this option may produce
         corrupted, invalid units or array data, but can lead to significant
         speedups in the input validation logic adds significant overhead. If
-        set, input_units *must* be a valid unit object. Defaults to False.
+        set, units *must* be a valid unit object. Defaults to False.
     name : string
         The name of the array. Defaults to None. This attribute does not propagate
         through mathematical operations, but is preserved under indexing
@@ -549,19 +549,11 @@ class unyt_array(np.ndarray):
         units=None,
         registry=None,
         dtype=None,
+        *,
         bypass_validation=False,
-        input_units=None,
         name=None,
     ):
-        # deprecate input_units in favor of units
-        if input_units is not None:
-            warnings.warn(
-                "input_units has been deprecated, please use units instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        if units is not None:
-            input_units = units
+        input_units = units
         if bypass_validation is True:
             if dtype is None:
                 dtype = input_array.dtype
@@ -2130,16 +2122,20 @@ class unyt_quantity(unyt_array):
 
     input_scalar : an integer or floating point scalar
         The scalar to attach units to
-    input_units : String unit specification, unit symbol object, or astropy
-                  units
+    units : String unit specification, unit symbol object, or astropy units
         The units of the quantity. Powers must be specified using python syntax
         (cm**3, not cm^3).
     registry : A UnitRegistry object
-        The registry to create units from. If input_units is already associated
+        The registry to create units from. If units is already associated
         with a unit registry and this is specified, this will be used instead
         of the registry associated with the unit object.
     dtype : data-type
         The dtype of the array data.
+    bypass_validation : boolean
+        If True, all input validation is skipped. Using this option may produce
+        corrupted, invalid units or array data, but can lead to significant
+        speedups in the input validation logic adds significant overhead. If
+        set, units *must* be a valid unit object. Defaults to False.
     name : string
         The name of the scalar. Defaults to None. This attribute does not propagate
         through mathematical operations, but is preserved under indexing
@@ -2176,18 +2172,11 @@ class unyt_quantity(unyt_array):
         units=None,
         registry=None,
         dtype=None,
+        *,
         bypass_validation=False,
-        input_units=None,
         name=None,
     ):
-        if input_units is not None:
-            warnings.warn(
-                "input_units has been deprecated, please use units instead",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        if units is not None:
-            input_units = units
+        input_units = units
         if not (
             bypass_validation
             or isinstance(input_scalar, (numeric_type, np.number, np.ndarray))

--- a/unyt/dask_array.py
+++ b/unyt/dask_array.py
@@ -224,7 +224,6 @@ class unyt_dask_array(DaskArray):
     registry
     bypass_validation
     unyt_name
-    input_units
 
     """
 
@@ -240,7 +239,6 @@ class unyt_dask_array(DaskArray):
         units=None,
         registry=None,
         bypass_validation=False,
-        input_units=None,
         unyt_name=None,
     ):
         # get the base dask array
@@ -261,9 +259,8 @@ class unyt_dask_array(DaskArray):
             units,
             registry,
             dtype,
-            bypass_validation,
-            input_units,
-            unyt_name,
+            bypass_validation=bypass_validation,
+            name=unyt_name,
         )
 
         obj.units = obj._unyt_array.units
@@ -537,7 +534,6 @@ def unyt_from_dask(
     *,
     registry=None,
     bypass_validation=False,
-    input_units=None,
     unyt_name=None,
 ):
     """
@@ -551,14 +547,14 @@ def unyt_from_dask(
         The units of the array. Powers must be specified using python
         syntax (cm**3, not cm^3).
     registry : :class:`unyt.unit_registry.UnitRegistry`
-        The registry to create units from. If input_units is already associated
+        The registry to create units from. If units is already associated
         with a unit registry and this is specified, this will be used instead
         of the registry associated with the unit object.
     bypass_validation : boolean
         If True, all input validation is skipped. Using this option may produce
         corrupted, invalid units or array data, but can lead to significant
         speedups in the input validation logic adds significant overhead. If
-        set, input_units *must* be a valid unit object. Defaults to False.
+        set, units *must* be a valid unit object. Defaults to False.
     unyt_name : string
         The name of the array. Defaults to None. This attribute does not propagate
         through mathematical operations, but is preserved under indexing
@@ -602,7 +598,6 @@ def unyt_from_dask(
         registry=registry,
         bypass_validation=bypass_validation,
         unyt_name=unyt_name,
-        input_units=input_units,
     )
 
     return da

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -14,7 +14,6 @@ import pickle
 import re
 import shutil
 import tempfile
-import warnings
 from importlib.metadata import version
 from pathlib import Path
 
@@ -2400,26 +2399,6 @@ def test_overflow_warnings():
     _process_warning(data.to, message, RuntimeWarning, ("mile",))
     _process_warning(data.in_units, message, RuntimeWarning, ("mile",))
     _process_warning(data.convert_to_units, message, RuntimeWarning, ("mile",))
-
-
-def test_input_units_deprecation():
-    from unyt.array import unyt_array, unyt_quantity
-
-    message = "input_units has been deprecated, please use units instead"
-
-    _process_warning(
-        unyt_array, message, DeprecationWarning, ([1, 2, 3],), {"input_units": "mile"}
-    )
-    _process_warning(
-        unyt_quantity, message, DeprecationWarning, (3,), {"input_units": "mile"}
-    )
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        assert_array_equal(
-            unyt_array([1, 2, 3], "mile"), unyt_array([1, 2, 3], input_units="mile")
-        )
-        assert unyt_quantity(3, "mile") == unyt_quantity(3, input_units="mile")
 
 
 def test_clip():


### PR DESCRIPTION
This is the only long standing deprecation that I found.
While I'm at it, I'm made `bypass_validation` and `name` keyword-only arguments, and updated docstrings