### PR TITLE
Drop support for numpy<1.19

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -152,7 +152,7 @@ These enable testing the docstrings and doctest examples scattered throughout
 the unyt and its documentation.
 
 You will need to install ``pytest`` and ``pytest-doctestplus`` to run this
-command. Some tests depend on ``h5py``, ``Pint``, ``astropy`` and ``matplotlib``
+command. Some tests depend on ``h5py``, ``Pint``, ``astropy``, ``matplotlib`` and ``dask``
 being installed.
 
 If you would like to run the tests on multiple python versions, first ensure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ keywords = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "numpy>=1.17.5",
+    "numpy>=1.19",
     "sympy>=1.5",
 ]
 dynamic = [

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ deps =
     docutils
     pytest
     sympy==1.5
-    numpy==1.17.5
+    numpy==1.19.0
     h5py==3.0.0
     pint==0.9
     astropy==3.2.3

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -1,10 +1,8 @@
 # tests for NumPy __array_function__ support
 import re
-from importlib.metadata import version
 
 import numpy as np
 import pytest
-from packaging.version import Version
 
 from unyt import A, K, cm, degC, degF, delta_degC, g, km, rad, s
 from unyt._array_functions import (
@@ -20,7 +18,6 @@ from unyt.exceptions import (
 )
 from unyt.testing import assert_array_equal_units
 
-NUMPY_VERSION = Version(version("numpy"))
 # this is a subset of NOT_HANDLED_FUNCTIONS for which there's nothing to do
 # because they don't apply to (real) numeric types
 # or they work as expected out of the box
@@ -862,9 +859,6 @@ def test_copy():
     assert type(y) is np.ndarray
 
 
-@pytest.mark.skipif(
-    NUMPY_VERSION < Version("1.19"), reason="np.copy's subok arg requires numpy 1.19+"
-)
 def test_copy_subok():
     x = [1, 2, 3] * cm
     y = np.copy(x, subok=True)
@@ -1587,13 +1581,6 @@ def test_triangles(func):
     assert res.units == cm
 
 
-@pytest.mark.skipif(
-    NUMPY_VERSION < Version("1.19"),
-    reason=(
-        "einsum raises a spurious TypeError with out=None and optimize=False "
-        "(which are default values)"
-    ),
-)
 def test_einsum():
     a = np.eye(4) * cm
 


### PR DESCRIPTION
As discussed in #401

Also added a missing mention of dask in the dev guide that I stumbled upon while scanning for dependencies.