### PR TITLE
Add tests to improve coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -96,4 +96,4 @@ commands =
 skip_install = true
 depends = py{38,39,310,311}
 deps =
-    coverage
+    coverage[toml]

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -213,7 +213,6 @@ def _difference_units(unit1, unit2=None):
                 "cannot be multiplied, divided, subtracted or "
                 "added with data that has different units."
             )
-
     if unit1.base_offset == 0.0:
         return 1, unit1
 
@@ -1765,18 +1764,6 @@ class unyt_array(np.ndarray):
         else:
             return super().__pow__(p, mod)
 
-    def __eq__(self, other):
-        try:
-            return super().__eq__(other)
-        except (IterableUnitCoercionError, UnitOperationError):
-            return np.zeros(self.shape, dtype="bool")
-
-    def __ne__(self, other):
-        try:
-            return super().__ne__(other)
-        except (IterableUnitCoercionError, UnitOperationError):
-            return np.ones(self.shape, dtype="bool")
-
     #
     # Start operation methods
     #
@@ -1962,26 +1949,10 @@ class unyt_array(np.ndarray):
                         "cannot be multiplied, divided, subtracted or added."
                     )
         else:
-            if ufunc is clip:
-                inp = []
-                for i in inputs:
-                    if isinstance(i, unyt_array):
-                        inp.append(i.to(inputs[0].units).view(np.ndarray))
-                    else:
-                        inp.append(i)
-                if out is not None:
-                    _out = out.view(np.ndarray)
-                else:
-                    _out = None
-                out_arr = ufunc(*inp, out=_out)
-                unit = inputs[0].units
-                ret_class = type(inputs[0])
-                mul = 1
-            else:
-                raise RuntimeError(
-                    "Support for the %s ufunc with %i inputs has not been "
-                    "added to unyt_array." % (str(ufunc), len(inputs))
-                )
+            raise RuntimeError(
+                "Support for the %s ufunc with %i inputs has not been "
+                "added to unyt_array." % (str(ufunc), len(inputs))
+            )
         if unit is None:
             out_arr = np.array(out_arr, copy=False)
         elif ufunc in (modf, divmod_):

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -692,8 +692,6 @@ def test_temperature_conversions():
     scales that have a proper zero point.
 
     """
-    from unyt.unit_object import InvalidUnitOperation
-
     km = unyt_quantity(1, "km", dtype="float64")
     balmy = unyt_quantity(300, "K", dtype="float64")
     balmy_F = unyt_quantity(80.33, "degF")


### PR DESCRIPTION
There are a bunch of new code paths that don't have tests, this adds some tests to cover them. It also deletes some old code paths that are no longer getting test coverage.

More explanation for the non-test changes:

* I noticed there was some inconsistency in which errors are raised by the `__array_function__` wrappers, so I decided to make all the errors raised there `InvalidUnitOperation`. This seems clearest to me.

* The `_sanitize_range` wrapper wasn't handling cases where the range is all unitless scalars, this adds support for that case.

* The tox coverage reports were broken so I fixed that.

* The custom code in the `except` block in `__eq__` and `__ne__` was never getting called so I deleted the `__eq__` and `__ne__` implementations.

* `clip` is now handled by the `__array_function__` wrapper, so I deleted the special handling for it in `__array_ufunc__`.