### PR TITLE
TST: add test for new regression with sympy 1.12

### DIFF
--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -19,7 +19,6 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-import sympy
 from numpy import array
 from numpy.testing import (
     assert_almost_equal,
@@ -848,11 +847,17 @@ def test_unyt_array_pickle():
         assert_equal(float(data.units.base_value), float(loaded_data.units.base_value))
 
 
+SYMPY_VERSION = Version(version("sympy"))
+
+
 @pytest.mark.xfail(
-    condition=(
-        (Version(sympy.__version__) == Version("1.9"))
-        or (Version(sympy.__version__) == Version("1.10"))
-    ),
+    condition=(SYMPY_VERSION == Version("1.12")),
+    reason="regression in sympy 1.12",
+    raises=AssertionError,
+    strict=True,
+)
+@pytest.mark.xfail(
+    condition=(SYMPY_VERSION in (Version("1.9"), Version("1.10"))),
     reason="Not resolved upstream as of sympy 1.10",
     raises=AttributeError,
     strict=True,
@@ -864,6 +869,8 @@ def test_unpickling_old_array():
     with open(PFILE, "rb") as fh:
         arr = pickle.load(fh)
 
+    # this comparison fails with sympy==1.12
+    # see https://github.com/sympy/sympy/issues/25134
     assert arr.units.dimensions == cm.dimensions
 
 

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -862,7 +862,9 @@ def test_unpickling_old_array():
     # the expected error is "AttributeError: 'One' object has no attribute '__dict__'"
     PFILE = Path(__file__).parent / "data" / "unyt_array_sympy1.8.pickle"
     with open(PFILE, "rb") as fh:
-        pickle.load(fh)
+        arr = pickle.load(fh)
+
+    assert arr.units.dimensions == cm.dimensions
 
 
 def test_copy():


### PR DESCRIPTION
There's a new incompatibility where a Unit object that was pickled with sympy 1.8 doesn't compare correctly with the same object generated with sympy 1.12. Unfortunately this case wasn't sufficiently tested so it was discovered _after_ sympy 1.12 was released, within yt test infrastructure.

This adds completes the regression test.

I'll report the issue upstream later today. I've identified the first broken commit as https://github.com/sympy/sympy/commit/40f0f6cfa2af216247476d3f416c715fefde6335
