### PR TITLE
STY: activate flake8-comprehensions (ruff)

### DIFF
--- a/docs/extensions/show_all_units.py
+++ b/docs/extensions/show_all_units.py
@@ -33,7 +33,7 @@ def setup(app):
     setup.config = app.config
     setup.confdir = app.confdir
 
-    retdict = dict(version="0.1")
+    retdict = {"version": "0.1"}
 
     return retdict
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ select = [
     "E",
     "F",
     "W",
+    "C4",  # flake8-comprehensions
     "B",   # flake8-bugbear
     "YTT", # flake8-2020
     "I",   # isort

--- a/unyt/_unit_lookup_table.py
+++ b/unyt/_unit_lookup_table.py
@@ -713,7 +713,7 @@ def generate_name_alternatives():
                     used_prefix = prefix
                 append_name(names[prefix + key], used_prefix + key, prefix + key)
         elif len(key) > 3 and key.title() != key:
-            if all([len(k) > 3 for k in key.split("_")]):
+            if all(len(k) > 3 for k in key.split("_")):
                 append_name(names[key], key, key.title())
         if key in default_unit_name_alternatives:
             alternatives = default_unit_name_alternatives[key]

--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -258,7 +258,7 @@ class UnitRegistry:
         are of equivalent dimensions to *unit_object*.
         """
         equiv = [k for k, v in self.lut.items() if v[1] is unit_object.dimensions]
-        equiv = list(sorted(set(equiv)))
+        equiv = sorted(set(equiv))
         return equiv
 
     def __deepcopy__(self, memodict=None):


### PR DESCRIPTION
follow up to #367

context:
Following [gist.github.com/aureliojargas/70bd3667afd18f2a4f4e23d7ae5a2915](https://gist.github.com/aureliojargas/70bd3667afd18f2a4f4e23d7ae5a2915):

Comprehension-related autofixes are not included in ruff's UP (pyupgrade) rule set because they are redundant with a subset of flake8-comprehensions. Here I'm choosing to activate the whole set of rules from this plugin for simplicity of configuration.