### PR TITLE
ENH: avoid unnecessary copies in np.historgram* functions

### DIFF
--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -145,7 +145,7 @@ def _sanitize_range(_range, units):
             raise TypeError(
                 f"Elements of range must both have a 'units' attribute. Got {_range}"
             )
-        new_range[i] = imin.to(units[i]).value, imax.to(units[i]).value
+        new_range[i] = imin.to_value(units[i]), imax.to_value(units[i])
     return new_range.squeeze()
 
 


### PR DESCRIPTION
A minor memory-management optimization: `unyt_array.to(units).value` makes two copies, `unyt_array.to_value(units)` only makes one.