### PR TITLE
TST: minimize build time in tox runs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -98,4 +98,4 @@ commands =
 skip_install = true
 depends = py{38,39,310,311}
 deps =
-    coverage
+    coverage[toml]

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ python =
     3.11: py311
 
 [testenv]
+package = wheel
+wheel_build_env = .pkg
 setenv =
     PYTHONPATH = {toxinidir}
     MPLBACKEND = agg


### PR DESCRIPTION
Just learned that tox 4 allows universal wheels to be built once and reused across multiple envs, reducing the build time to a minimum.
https://tox.wiki/en/latest/upgrading.html#universal-wheels