### PR TITLE
PERF: lazily define physical constants aliases

### DIFF
--- a/unyt/__init__.py
+++ b/unyt/__init__.py
@@ -62,21 +62,14 @@ from unyt.unit_systems import UnitSystem  # NOQA: F401
 from ._version import __version__
 
 
-# function to only import quantities into this namespace
-# we go through the trouble of doing this instead of "import *"
-# to avoid including extraneous variables (e.g. floating point
-# constants used to *construct* a physical constant) in this namespace
-def import_units(module, namespace):
-    """Import Unit objects from a module into a namespace"""
-    for key, value in module.__dict__.items():
-        if isinstance(value, (unyt_quantity, Unit)):
-            namespace[key] = value
-
-
-import_units(unit_symbols, globals())
-import_units(physical_constants, globals())
-
-del import_units
+def __getattr__(name):
+    if isinstance(
+        attr := getattr(physical_constants, name, None), (unyt_quantity, Unit)
+    ):
+        return attr
+    if isinstance(attr := getattr(unit_symbols, name, None), (unyt_quantity, Unit)):
+        return attr
+    raise AttributeError
 
 
 def test():  # pragma: no cover

--- a/unyt/physical_constants.py
+++ b/unyt/physical_constants.py
@@ -17,7 +17,51 @@ For example::
 """
 
 
-from unyt.unit_registry import default_unit_registry as _default_unit_registry
-from unyt.unit_systems import add_constants as _add_constants
+from itertools import chain as _chain
 
-_add_constants(globals(), registry=_default_unit_registry)
+from unyt._unit_lookup_table import physical_constants as _physical_constants
+from unyt.array import unyt_quantity
+from unyt.unit_registry import default_unit_registry as _default_unit_registry
+
+_mks_csts = dict.fromkeys(_physical_constants.keys())
+_alt2csts = dict.fromkeys(
+    _chain.from_iterable(
+        alt_names for (_, _, alt_names) in _physical_constants.values()
+    )
+)
+
+
+for constant_name, (value, unit_name, alternate_names) in _physical_constants.items():
+    _alt2csts[constant_name] = constant_name
+    _alt2csts.update({alt: constant_name for alt in alternate_names})
+    _mks_csts[constant_name] = unyt_quantity(
+        value, unit_name, registry=_default_unit_registry
+    )
+
+
+def __getattr__(name):
+    from unyt.exceptions import UnitsNotReducible
+
+    if name in _mks_csts:
+        try:
+            return _mks_csts[name].in_base(_default_unit_registry.unit_system)
+        except UnitsNotReducible:
+            return _mks_csts[name]
+
+    if name.endswith("_mks") and name[:-4] in _alt2csts:
+        return _mks_csts[_alt2csts[name[:-4]]]
+    elif name.endswith("_cgs") and name[:-4] in _alt2csts:
+        try:
+            return _mks_csts[_alt2csts[name[:-4]]].in_cgs()
+        except UnitsNotReducible:
+            pass
+    elif name in _alt2csts:
+        return _mks_csts[_alt2csts[name]]
+    elif name == "hmks":
+        # backward compatibility for unyt 1.0
+        return _mks_csts["h"]
+    elif name == "hcgs":
+        # backward compatibility for unyt 1.0
+        return _mks_csts["h"].in_cgs()
+
+    raise AttributeError


### PR DESCRIPTION
This reduces by half the import penalty from unyt itself. Meaning, following `import numpy; import sympy; import sympy.tensor.tensor`, `import unyt` costs 250ms on my machine, and down to 120ms with this branch.

The idea is to avoid generating hundreds of rarely used quantities (based on how often they appear in tests, or yt) on import.
This comes a the cost of a (small ?) breaking changea:
`from unyt import *` won't import lazily generated aliases to physical constants (like `mass_sun`, `c_mks` ...). They are now only accessible if imported explicitly.

It may be possible to alleviate this by defining `__all__` module attributes. However I don't see a way to do it dynamically (cases where `UnitsNotReducible` is raised should not be included), and I'm not sure doing it statically is worth it.

Note that I'm keeping `unyt.unit_systems.add_constants` even if not used internally any more because it is still used in yt, but it should be possible to avoid it there too and deprecate it here.

The cost in breaking change in my eye small and worth the gain, but it's still breaking, so I'm proposing this for inclusion in the 3.0 release.