### PR TITLE
Allow dimension-checking of multiple return values

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -329,6 +329,17 @@ using the :meth:`@accepts <unyt.dimensions.accepts>` and :meth:`@returns <unyt.d
   >>> print(res)
   6 m
 
+:meth:`@accepts <unyt.dimensions.accepts>` can specify the dimensions of any subset of inputs and :meth:`@returns <unyt.dimensions.returns>` must always describe all outputs.
+
+  >>> @returns(length, length/time**2)
+  >>> @accepts(v=length/time)
+  ... def bar(a, v):
+  ...     return a * v, v / a
+  ...
+  >>> res = bar(a= 2 * u.s, v = 3 * u.m/u.s)
+  >>> print(*res)
+  6 m 1.5 m/s**2
+
 .. note::
    Using these decorators may incur some performance overhead, especially for small arrays.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -325,7 +325,7 @@ using the :meth:`@accepts <unyt.dimensions.accepts>` and :meth:`@returns <unyt.d
   ... def foo(a, v):
   ...     return a * v
   ...
-  >>> res = foo(a= 2 * u.s, v = 3 * u.m/u.s)
+  >>> res = foo(a=2*u.s, v=3*u.m/u.s)
   >>> print(res)
   6 m
 
@@ -336,7 +336,7 @@ using the :meth:`@accepts <unyt.dimensions.accepts>` and :meth:`@returns <unyt.d
   ... def bar(a, v):
   ...     return a * v, v / a
   ...
-  >>> res = bar(a= 2 * u.s, v = 3 * u.m/u.s)
+  >>> res = bar(a=2*u.s, v=3*u.m/u.s)
   >>> print(*res)
   6 m 1.5 m/s**2
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -332,7 +332,7 @@ using the :meth:`@accepts <unyt.dimensions.accepts>` and :meth:`@returns <unyt.d
 :meth:`@accepts <unyt.dimensions.accepts>` can specify the dimensions of any subset of inputs and :meth:`@returns <unyt.dimensions.returns>` must always describe all outputs.
 
   >>> @returns(length, length/time**2)
-  >>> @accepts(v=length/time)
+  ... @accepts(v=length/time)
   ... def bar(a, v):
   ...     return a * v, v / a
   ...

--- a/unyt/dimensions.py
+++ b/unyt/dimensions.py
@@ -359,7 +359,7 @@ def returns(*r_unit):
             if isinstance(results, tuple):
                 result_tuple = results
             else:
-                result_tuple = results,
+                result_tuple = (results,)
 
             for result, dimension in zip(result_tuple, r_unit):
                 if not _has_dimensions(result, dimension):

--- a/unyt/dimensions.py
+++ b/unyt/dimensions.py
@@ -11,6 +11,8 @@ from itertools import chain
 
 from sympy import Rational, Symbol, sympify
 
+from unyt._deprecation import warn_deprecated
+
 #: mass
 mass = Symbol("(mass)", positive=True)
 #: length
@@ -337,11 +339,10 @@ def returns(*r_units, r_unit=None):
                 "Cannot specify `r_unit` and other return values simultaneously"
             )
         else:
-            warnings.warn(
-                "Use of the @returns(r_unit=...) syntax is deprecated. "
-                "Please use @returns(...) instead.",
-                category=DeprecationWarning,
-                stacklevel=2,
+            warn_deprecated(
+                "@unyt.returns(r_unit=...)",
+                replacement="use @unyt.returns(...)",
+                since_version="3.0",
             )
             r_units = (r_unit,)
 

--- a/unyt/dimensions.py
+++ b/unyt/dimensions.py
@@ -361,7 +361,7 @@ def returns(*r_unit):
             else:
                 result_tuple = results,
 
-            for result, dimension in zip(result_tuple, r_unit, strict=True):
+            for result, dimension in zip(result_tuple, r_unit):
                 if not _has_dimensions(result, dimension):
                     raise TypeError(f"result '{result}' does not match {dimension}")
             return results

--- a/unyt/dimensions.py
+++ b/unyt/dimensions.py
@@ -5,7 +5,6 @@ Dimensions of physical quantities
 """
 
 
-import warnings
 from functools import wraps
 from itertools import chain
 

--- a/unyt/tests/test_unyt_testing.py
+++ b/unyt/tests/test_unyt_testing.py
@@ -49,13 +49,13 @@ def test_accepts():
     def foo(a, v):
         return a * v
 
-    _ = foo(a=2 * second, v=3 * meter / second)
+    foo(a=2 * second, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        _ = foo(a=2 * meter, v=3 * meter / second)
+        foo(a=2 * meter, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        _ = foo(a=2 * second, v=3 * meter)
+        foo(a=2 * second, v=3 * meter)
 
 
 def test_accepts_partial():
@@ -63,21 +63,21 @@ def test_accepts_partial():
     def bar(a, v):
         return a * v
 
-    _ = bar(a=2 * second, v=3 * meter / second)
-    _ = bar(a=2 * second, v=3 * meter)
+    bar(a=2 * second, v=3 * meter / second)
+    bar(a=2 * second, v=3 * meter)
 
     with pytest.raises(TypeError):
-        _ = bar(a=2 * meter, v=3 * meter / second)
+        bar(a=2 * meter, v=3 * meter / second)
 
     @accepts(v=length / time)
     def baz(a, v):
         return a * v
 
-    _ = baz(a=2 * second, v=3 * meter / second)
-    _ = baz(a=2 * meter, v=3 * meter / second)
+    baz(a=2 * second, v=3 * meter / second)
+    baz(a=2 * meter, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        _ = baz(a=2 * second, v=3 * meter)
+        baz(a=2 * second, v=3 * meter)
 
 
 def test_returns():
@@ -85,13 +85,13 @@ def test_returns():
     def foo(a, v):
         return a * v
 
-    _ = foo(a=2 * second, v=3 * meter / second)
+    foo(a=2 * second, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        _ = foo(a=2 * meter, v=3 * meter / second)
+        foo(a=2 * meter, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        _ = foo(a=2 * second, v=3 * meter)
+        foo(a=2 * second, v=3 * meter)
 
 
 def test_returns_multiple():
@@ -99,10 +99,10 @@ def test_returns_multiple():
     def bar(a, v):
         return a, v
 
-    _ = bar(a=2 * second, v=3 * meter / second)
+    bar(a=2 * second, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        _ = bar(a=2 * meter, v=3 * meter / second)
+        bar(a=2 * meter, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        _ = bar(a=2 * second, v=3 * meter)
+        bar(a=2 * second, v=3 * meter)

--- a/unyt/tests/test_unyt_testing.py
+++ b/unyt/tests/test_unyt_testing.py
@@ -4,7 +4,9 @@ Test unyt.testing module that contains utilities for writing tests.
 """
 import pytest
 
+from unyt import accepts, meter, returns, second
 from unyt.array import unyt_array, unyt_quantity
+from unyt.dimensions import length, time
 from unyt.testing import assert_allclose_units
 
 
@@ -40,3 +42,63 @@ def test_atol_conversion_error():
     a2 = unyt_array([1.0, 2.0, 3.0], "cm")
     with pytest.raises(AssertionError):
         assert_allclose_units(a1, a2, atol=unyt_quantity(0.0, "kg"))
+
+def test_accepts():
+    @accepts(a=time, v=length/time)
+    def foo(a, v):
+        return a * v
+
+    _ = foo(a = 2 * second, v = 3 * meter / second)
+
+    with pytest.raises(TypeError):
+        _ = foo(a = 2 * meter, v = 3 * meter / second)
+
+    with pytest.raises(TypeError):
+        _ = foo(a = 2 * second, v = 3 * meter)
+
+def test_accepts_partial():
+    @accepts(a=time)
+    def bar(a, v):
+        return a * v
+
+    _ = bar(a = 2 * second, v = 3 * meter / second)
+    _ = bar(a = 2 * second, v = 3 * meter)
+
+    with pytest.raises(TypeError):
+        _ = bar(a = 2 * meter, v = 3 * meter / second)
+
+    @accepts(v=length/time)
+    def baz(a, v):
+        return a * v
+
+    _ = baz(a = 2 * second, v = 3 * meter / second)
+    _ = baz(a = 2 * meter, v = 3 * meter / second)
+
+    with pytest.raises(TypeError):
+        _ = baz(a = 2 * second, v = 3 * meter)
+
+def test_returns():
+    @returns(length)
+    def foo(a, v):
+        return a * v
+
+    _ = foo(a = 2 * second, v = 3 * meter / second)
+
+    with pytest.raises(TypeError):
+        _ = foo(a = 2 * meter, v = 3 * meter / second)
+
+    with pytest.raises(TypeError):
+        _ = foo(a = 2 * second, v = 3 * meter)
+
+def test_returns_multiple():
+    @returns(time, length/time)
+    def bar(a, v):
+        return a, v
+
+    _ = bar(a= 2 * second, v = 3 * meter / second)
+
+    with pytest.raises(TypeError):
+        _ = bar(a = 2 * meter, v = 3 * meter / second)
+
+    with pytest.raises(TypeError):
+        _ = bar(a = 2 * second, v = 3 * meter)

--- a/unyt/tests/test_unyt_testing.py
+++ b/unyt/tests/test_unyt_testing.py
@@ -85,24 +85,39 @@ def test_returns():
     def foo(a, v):
         return a * v
 
-    foo(a=2 * second, v=3 * meter / second)
+    # This usage is deprecated, but we still want to support it for now.
+    with pytest.deprecated_call():
 
-    with pytest.raises(TypeError):
-        foo(a=2 * meter, v=3 * meter / second)
+        @returns(r_unit=length)
+        def bar(a, v):
+            return a * v
 
-    with pytest.raises(TypeError):
-        foo(a=2 * second, v=3 * meter)
+    for func in [foo, bar]:
+        func(a=2 * second, v=3 * meter / second)
+
+        with pytest.raises(TypeError):
+            func(a=2 * meter, v=3 * meter / second)
+
+        with pytest.raises(TypeError):
+            func(a=2 * second, v=3 * meter)
+
+    # We don't support a mixture of the two usage styles.
+    with pytest.raises(ValueError):
+
+        @returns(length, r_unit=time)
+        def _(a, v):
+            return a, v
 
 
 def test_returns_multiple():
     @returns(time, length / time)
-    def bar(a, v):
+    def baz(a, v):
         return a, v
 
-    bar(a=2 * second, v=3 * meter / second)
+    baz(a=2 * second, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        bar(a=2 * meter, v=3 * meter / second)
+        baz(a=2 * meter, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        bar(a=2 * second, v=3 * meter)
+        baz(a=2 * second, v=3 * meter)

--- a/unyt/tests/test_unyt_testing.py
+++ b/unyt/tests/test_unyt_testing.py
@@ -43,62 +43,66 @@ def test_atol_conversion_error():
     with pytest.raises(AssertionError):
         assert_allclose_units(a1, a2, atol=unyt_quantity(0.0, "kg"))
 
+
 def test_accepts():
-    @accepts(a=time, v=length/time)
+    @accepts(a=time, v=length / time)
     def foo(a, v):
         return a * v
 
-    _ = foo(a = 2 * second, v = 3 * meter / second)
+    _ = foo(a=2 * second, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        _ = foo(a = 2 * meter, v = 3 * meter / second)
+        _ = foo(a=2 * meter, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        _ = foo(a = 2 * second, v = 3 * meter)
+        _ = foo(a=2 * second, v=3 * meter)
+
 
 def test_accepts_partial():
     @accepts(a=time)
     def bar(a, v):
         return a * v
 
-    _ = bar(a = 2 * second, v = 3 * meter / second)
-    _ = bar(a = 2 * second, v = 3 * meter)
+    _ = bar(a=2 * second, v=3 * meter / second)
+    _ = bar(a=2 * second, v=3 * meter)
 
     with pytest.raises(TypeError):
-        _ = bar(a = 2 * meter, v = 3 * meter / second)
+        _ = bar(a=2 * meter, v=3 * meter / second)
 
-    @accepts(v=length/time)
+    @accepts(v=length / time)
     def baz(a, v):
         return a * v
 
-    _ = baz(a = 2 * second, v = 3 * meter / second)
-    _ = baz(a = 2 * meter, v = 3 * meter / second)
+    _ = baz(a=2 * second, v=3 * meter / second)
+    _ = baz(a=2 * meter, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        _ = baz(a = 2 * second, v = 3 * meter)
+        _ = baz(a=2 * second, v=3 * meter)
+
 
 def test_returns():
     @returns(length)
     def foo(a, v):
         return a * v
 
-    _ = foo(a = 2 * second, v = 3 * meter / second)
+    _ = foo(a=2 * second, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        _ = foo(a = 2 * meter, v = 3 * meter / second)
+        _ = foo(a=2 * meter, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        _ = foo(a = 2 * second, v = 3 * meter)
+        _ = foo(a=2 * second, v=3 * meter)
+
 
 def test_returns_multiple():
-    @returns(time, length/time)
+    @returns(time, length / time)
     def bar(a, v):
         return a, v
 
-    _ = bar(a= 2 * second, v = 3 * meter / second)
+    _ = bar(a=2 * second, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        _ = bar(a = 2 * meter, v = 3 * meter / second)
+        _ = bar(a=2 * meter, v=3 * meter / second)
 
     with pytest.raises(TypeError):
-        _ = bar(a = 2 * second, v = 3 * meter)
+        _ = bar(a=2 * second, v=3 * meter)


### PR DESCRIPTION
Extend the `@returns` decorator so it can handle functions with multiple return values.

Example:
```python
>>> @returns(length, length/time**2)
... def f(a, v):
...     return a * v, v / a
...
>>> res = f(a= 2 * u.s, v = 3 * u.m/u.s)
>>> print(*res)
6 m 1.5 m/s**2
```

I think I've followed everything in [CONTRIBUTING](https://github.com/yt-project/unyt/blob/main/CONTRIBUTING.rst), but please let me know if I've missed anything.