### PR TITLE
BUG: fix converting a dimensionless array with unyt_array.to_astropy

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1313,7 +1313,11 @@ class unyt_array(np.ndarray):
         >>> data.to_astropy()
         <Quantity [3., 4., 5.] g / cm3>
         """
-        return self.value * _astropy.units.Unit(str(self.units), **kwargs)
+        if self.units.is_dimensionless:
+            s_units = ""
+        else:
+            s_units = str(self.units)
+        return self.value * _astropy.units.Unit(s_units, **kwargs)
 
     @classmethod
     def from_pint(cls, arr, unit_registry=None):

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -1402,6 +1402,17 @@ def test_astropy():
     assert_equal(yt_quan, unyt_quantity.from_astropy(yt_quan.to_astropy()))
 
 
+def test_astropy_dimensionless():
+    # see https://github.com/yt-project/unyt/issues/436
+    pytest.importorskip("astropy")
+
+    arr = unyt_array([1, 2, 3], "")
+    ap_arr = np.array([1, 2, 3]) * _astropy.units.Unit("")
+
+    assert_array_equal(ap_arr, arr.to_astropy())
+    assert_array_equal(arr, unyt_array.from_astropy(ap_arr))
+
+
 def test_pint():
     pytest.importorskip("pint")
 


### PR DESCRIPTION
closes #436