### PR TITLE
BUG: fix an incompatibility with numpy 2.0 (np.asfarray is removed)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ requires-python = ">=3.8"
 dependencies = [
     "numpy>=1.19",
     "sympy>=1.5",
+    "packaging>=20.9",
 ]
 dynamic = [
     "version",

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ deps =
     pint
     astropy
     coverage[toml]>=5.0
-    packaging>=20.9
     pytest-cov
     pytest-doctestplus
     matplotlib!=3.5.0

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -1,7 +1,9 @@
 import warnings
+from importlib.metadata import version
 from numbers import Number
 
 import numpy as np
+from packaging.version import Version
 
 from unyt import delta_degC
 from unyt.array import NULL_UNIT, unyt_array, unyt_quantity
@@ -11,6 +13,8 @@ from unyt.exceptions import (
     UnitInconsistencyError,
     UnytError,
 )
+
+NUMPY_VERSION = Version(version("numpy"))
 
 # Functions for which passing units doesn't make sense
 # bail out with NotImplemented (escalated to TypeError by numpy)
@@ -345,12 +349,6 @@ def around(a, decimals=0, out=None):
     if getattr(out, "units", None) is not None:
         out.units = ret_units
     return unyt_array(res, ret_units, bypass_validation=True)
-
-
-@implements(np.asfarray)
-def asfarray(a, dtype=np.double):
-    ret_units = a.units
-    return np.asfarray._implementation(a.view(np.ndarray), dtype=dtype) * ret_units
 
 
 @implements(np.block)
@@ -1006,3 +1004,11 @@ def array_repr(arr, *args, **kwargs):
         return rep[:-1] + ", units='" + units_repr + "')"
     else:
         return rep[:-1] + ", '" + units_repr + "')"
+
+
+if NUMPY_VERSION < Version("2.0.0dev0"):
+    # functions that are removed in numpy 2.0.0
+    @implements(np.asfarray)
+    def asfarray(a, dtype=np.double):
+        ret_units = a.units
+        return np.asfarray._implementation(a.view(np.ndarray), dtype=dtype) * ret_units

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -1,8 +1,10 @@
 # tests for NumPy __array_function__ support
 import re
+from importlib.metadata import version
 
 import numpy as np
 import pytest
+from packaging.version import Version
 
 from unyt import A, K, cm, degC, delta_degC, g, km, rad, s
 from unyt._array_functions import (
@@ -16,6 +18,8 @@ from unyt.exceptions import (
     UnytError,
 )
 from unyt.testing import assert_array_equal_units
+
+NUMPY_VERSION = Version(version("numpy"))
 
 # this is a subset of NOT_HANDLED_FUNCTIONS for which there's nothing to do
 # because they don't apply to (real) numeric types
@@ -633,6 +637,9 @@ def test_append_inconsistent_units():
         np.append(a, [4, 5, 6])
 
 
+@pytest.mark.skipif(
+    NUMPY_VERSION >= Version("2.0.0dev0"), reason="np.asfarray is removed in numpy 2.0"
+)
 def test_asfarray():
     x1 = np.eye(3, dtype="int64") * cm
 


### PR DESCRIPTION
Fix a new incompatibility with numpy's dev branch (see https://github.com/numpy/numpy/pull/24376)

This bug only affects unyt 3.0, and the fix doesn't need a backport.
