### PR TITLE
TST: filter a new warning in maptlotlib 3.8 when testing docs in non-interactive agg backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ addopts = "--ignore=benchmarks --ignore=paper --ignore=unyt/_mpl_array_converter
 filterwarnings = [
     "error",
     "ignore:Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.:UserWarning",
+    "ignore:FigureCanvasAgg is non-interactive, and thus cannot be shown:UserWarning",
     "ignore:In accordance with NEP 32:DeprecationWarning",
     "ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning",
 ]


### PR DESCRIPTION
fix a new instability in CI caused by the release of matplotlib 3.8.0 yesterday