### PR TITLE
TST: unlock numpy 2.0 on bleeding-edge CI

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -41,13 +41,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools wheel setuptools_scm
-        python -m pip install --pre --extra-index \
-          https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy matplotlib
+        python -m pip install --pre numpy --only-binary ":all:" --extra-index \
+          https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
         python -m pip install pytest
         python -m pip install --pre sympy
 
     - name: Build unyt
       run: python -m pip install --no-build-isolation .
+
+    - run: python -m pip list
 
     - name: Run Tests
       run: pytest -vvv unyt/


### PR DESCRIPTION
At the moment, bleeding edge CI picks up matplotlib nightlies, but this results in downgrading numpy to a stable release (see https://github.com/matplotlib/matplotlib/issues/26847#issuecomment-1729927820)

matplotlib is not a hard dependency to unyt, and we're just using it to test the stability of integrations, but numpy is an absolute core dependency, so I think there's more value in trying to catch incompatibilities with it than with matplotlib.
This patch proposes to limit nightlies tests to core dependencies.