### PR TITLE
TST: add CPython 3.12 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
         # Test all on ubuntu, test ends on macos and windows
         include:
           - os: macos-latest
@@ -29,9 +30,9 @@ jobs:
           - os: windows-latest
             python-version: '3.8'
           - os: macos-latest
-            python-version: '3.11'
+            python-version: '3.12'
           - os: windows-latest
-            python-version: '3.11'
+            python-version: '3.12'
 
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 keywords = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-docs,begin,py38-dependencies,py38-versions,py{38,39,310,311},py38-unyt-module-test-function,end
+envlist = py38-docs,begin,py38-dependencies,py38-versions,py{38,39,310,311,312},py38-unyt-module-test-function,end
 isolated_build = True
 
 [gh-actions]
@@ -8,6 +8,7 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 setenv =
@@ -93,6 +94,6 @@ commands =
     coverage report --omit='.tox/*'
     coverage html --omit='.tox/*'
 skip_install = true
-depends = py{38,39,310,311}
+depends = py{38,39,310,311,312}
 deps =
     coverage


### PR DESCRIPTION
With the release of h5py 3.10.0 (including cp312 wheels), I expect this to be possible. If there are any unexpected blockers we should be able to catch them in CI