### PR TITLE
BUG: fix future incompatibility with numpy 2.0 (numpy.core isn't public API)

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -102,7 +102,6 @@ from numpy import (
     true_divide,
     trunc,
 )
-from numpy.core.umath import _ones_like
 from sympy import Rational
 
 from unyt._on_demand_imports import _astropy, _dask, _pint
@@ -563,7 +562,6 @@ class unyt_array(np.ndarray):
         divmod_: _passthrough_unit,
         isnat: _return_without_unit,
         heaviside: _preserve_units,
-        _ones_like: _preserve_units,
         matmul: _multiply_units,
         clip: _passthrough_unit,
     }
@@ -1754,9 +1752,7 @@ class unyt_array(np.ndarray):
         """
         Power function
         """
-        # over-rides the ufunc as ``numpy`` passes the ``_ones_like`` ufunc for
-        # powers of zero (in some cases), which leads to an incorrect unit
-        # calculation.
+        # see https://github.com/yt-project/unyt/issues/203
         if p == 0.0:
             ret = self.ua
             ret.units = Unit("dimensionless")


### PR DESCRIPTION
fix an on-going failure in bleeding-edge CI

Context:
https://github.com/numpy/numpy/pull/24634


The comment I'm removing is from https://github.com/yt-project/unyt/pull/204. Local testing suggests that it's not necessary anymore (tests introduced in the same PR still pass), I suspect this is due to bumping our minimal requirements for numpy since that PR.

Opening as a draft for validation against the full CI. If all goes well, I'll try to remove `unyt_array.__pow__` completely
