### PR TITLE
Handle duplicate symbols in the unyt top-level namespace

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -22,8 +22,12 @@ constants defined in :mod:`unyt`, see :ref:`unit-listing`.
     :mod:`unyt` namespace. Some names occur as both unit symbols and physical
     constants, e.g. ``"me"``, ``"mp"``, ``"E_pl"``, etc. In such cases, the
     top-level namespace defaults to exporting the physical constant with the
-    duplicate name. As described below, there are other ways to import the
-    unit symbols and/or physical constants besides the top-level namespace.
+    duplicate name. This means that there may be a (very rare) case where an
+    :class:`Unit <unyt.unit_object.Unit>` object that at one point can be
+    imported from the top-level namespace may at a later point be only imported
+    as an :class:`unyt_quantity <unyt.array.unyt_quantity>` object with the
+    same name. As described below, there are other ways to import the unit
+    symbols and/or physical constants besides the top-level namespace.
 
 An Example from High School Physics
 -----------------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -16,6 +16,15 @@ use to attach units to NumPy arrays and other common Python data container types
 like ``list`` and ``tuple``. For an exhaustive listing of units and physical
 constants defined in :mod:`unyt`, see :ref:`unit-listing`.
 
+.. warning::
+
+    Both unit symbols and physical constants are defined in the top-level
+    :mod:`unyt` namespace. Some names occur as both unit symbols and physical
+    constants, e.g. ``"me"``, ``"mp"``, ``"E_pl"``, etc. In such cases, the
+    top-level namespace defaults to exporting the physical constant with the
+    duplicate name. As described below, there are other ways to import the
+    unit symbols and/or physical constants besides the top-level namespace.
+
 An Example from High School Physics
 -----------------------------------
 
@@ -96,7 +105,6 @@ that's all handled internally by :mod:`unyt`. Also note how the
 :meth:`unyt_array.to <unyt.array.unyt_array.to>` method was able to
 automatically handle the conversion from seconds to days and how the
 shorthand ``"d"`` was automatically interpreted as ``"day"``.
-
 
 Arithmetic and units
 --------------------

--- a/unyt/__init__.py
+++ b/unyt/__init__.py
@@ -69,12 +69,12 @@ from ._version import __version__
 def import_units(module, namespace):
     """Import Unit objects from a module into a namespace"""
     for key, value in module.__dict__.items():
-        if isinstance(value, (unyt_quantity, Unit)):
+        if key not in namespace and isinstance(value, (unyt_quantity, Unit)):
             namespace[key] = value
 
 
-import_units(unit_symbols, globals())
 import_units(physical_constants, globals())
+import_units(unit_symbols, globals())
 
 del import_units
 

--- a/unyt/_unit_lookup_table.py
+++ b/unyt/_unit_lookup_table.py
@@ -524,7 +524,6 @@ default_base_units = {
 physical_constants = OrderedDict(
     [
         ("me", (mass_electron_kg, "kg", ["mass_electron", "electron_mass"])),
-        ("amu", (amu_kg, "kg", ["atomic_mass_unit"])),
         ("Na", (avogadros_number, "mol**-1", ["Avogadros_number", "avogadros_number"])),
         ("mp", (mass_proton_kg, "kg", ["proton_mass", "mass_proton"])),
         ("mh", (mass_hydrogen_kg, "kg", ["hydrogen_mass", "mass_hydrogen"])),

--- a/unyt/tests/test_no_duplicates.py
+++ b/unyt/tests/test_no_duplicates.py
@@ -1,0 +1,16 @@
+def test_no_duplicates():
+    import unyt.unit_symbols as us
+    from unyt._unit_lookup_table import (
+        physical_constants,
+    )
+
+    symbol_names = {name for name in vars(us) if not name.startswith("_")}
+    constant_names = set(physical_constants.keys())
+
+    dups = symbol_names.intersection(constant_names)
+    try:
+        assert dups == {}
+    except AssertionError:
+        raise ValueError(
+            f"Duplicate names found between unit symbols and constants: {dups}"
+        )

--- a/unyt/tests/test_no_duplicates.py
+++ b/unyt/tests/test_no_duplicates.py
@@ -1,16 +1,13 @@
 def test_no_duplicates():
-    import unyt.unit_symbols as us
-    from unyt._unit_lookup_table import (
-        physical_constants,
-    )
+    import unyt
+    from unyt import physical_constants, unit_symbols
+    from unyt.array import unyt_quantity
 
-    symbol_names = {name for name in vars(us) if not name.startswith("_")}
-    constant_names = set(physical_constants.keys())
+    symbol_names = {key for key in unit_symbols.__dict__ if not key.startswith("_")}
+    constant_names = {
+        key for key in physical_constants.__dict__ if not key.startswith("_")
+    }
 
     dups = symbol_names.intersection(constant_names)
-    try:
-        assert dups == {}
-    except AssertionError:
-        raise ValueError(
-            f"Duplicate names found between unit symbols and constants: {dups}"
-        )
+    for dup in dups:
+        assert isinstance(getattr(unyt, dup), unyt_quantity)


### PR DESCRIPTION
This PR handles duplicate symbols from `unit_symbols` (`Unit` objects) and `physical_constants` (`unyt_quantity` objects) in the `unyt` top-level namespace.

* It removes `amu` as a physical constant, since it is typically used as a unit of measure.
* For all other duplicates in the top-level namespace, physical constants are what will be exposed. 
* Documents the fact that duplicates in the top-level namespace defer to physical constants.

Resolves Issue https://github.com/yt-project/unyt/issues/440. 