### PR TITLE
Drop python 3.8 support, update package support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
@@ -26,9 +25,9 @@ jobs:
         # Test all on ubuntu, test ends on macos and windows
         include:
           - os: macos-latest
-            python-version: '3.8'
+            python-version: '3.9'
           - os: windows-latest
-            python-version: '3.8'
+            python-version: '3.9'
           - os: macos-latest
             python-version: '3.12'
           - os: windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ keywords = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "numpy>=1.19",
+    "numpy>=1.19.3",
     "sympy>=1.5",
     "packaging>=20.9",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 keywords = [
     "unyt",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.19",
     "sympy>=1.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ keywords = [
 requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.19.3",
-    "sympy>=1.5",
+    "sympy>=1.7",
     "packaging>=20.9",
 ]
 dynamic = [

--- a/tox.ini
+++ b/tox.ini
@@ -35,11 +35,11 @@ deps =
     docutils
     pytest
     sympy==1.5
-    numpy==1.19.0
+    numpy==1.19.3
     h5py==3.0.0
     pint==0.9
-    astropy==3.2.3
-    matplotlib==3.2.0
+    astropy==4.0.4
+    matplotlib==3.3.3
     coverage[toml]
     pytest-cov
     pytest-doctestplus

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 deps =
     docutils
     pytest
-    sympy==1.5
+    sympy==1.7
     numpy==1.19.3
     h5py==3.0.0
     pint==0.9

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py38-docs,begin,py38-dependencies,py38-versions,py{38,39,310,311,312},py38-unyt-module-test-function,end
+envlist = py39-docs,begin,py39-dependencies,py39-versions,py{39,310,311,312},py39-unyt-module-test-function,end
 isolated_build = True
 
 [gh-actions]
 python =
-    3.8: py38, py38-docs, py38-dependencies, py38-versions, py38-unyt-module-test-function
-    3.9: py39
+    3.9: py39, py39-docs, py39-dependencies, py39-versions, py39-unyt-module-test-function
     3.10: py310
     3.11: py311
     3.12: py312
@@ -31,7 +30,7 @@ commands =
     pytest --cov=unyt --cov-append --doctest-modules --doctest-plus --doctest-rst --basetemp={envtmpdir}
     coverage report --omit='.tox/*'
 
-[testenv:py38-versions]
+[testenv:py39-versions]
 deps =
     docutils
     pytest
@@ -50,7 +49,7 @@ commands =
     pytest --cov=unyt --cov-append --basetemp={envtmpdir}
     coverage report --omit='.tox/*'
 
-[testenv:py38-dependencies]
+[testenv:py39-dependencies]
 deps =
     docutils
     pytest
@@ -64,7 +63,7 @@ commands =
     pytest --cov=unyt --cov-append --doctest-modules --doctest-plus --basetemp={envtmpdir}
     coverage report --omit='.tox/*'
 
-[testenv:py38-docs]
+[testenv:py39-docs]
 allowlist_externals = make
 changedir = docs
 deps =
@@ -76,8 +75,8 @@ commands =
     make clean
     python -m sphinx -M html "." "_build" -W
 
-[testenv:py38-unyt-module-test-function]
-depends = py38
+[testenv:py39-unyt-module-test-function]
+depends = py39
 commands =
     python -c 'import unyt; unyt.test()'
 
@@ -94,6 +93,6 @@ commands =
     coverage report --omit='.tox/*'
     coverage html --omit='.tox/*'
 skip_install = true
-depends = py{38,39,310,311,312}
+depends = py{39,310,311,312}
 deps =
     coverage

--- a/unyt/_on_demand_imports.py
+++ b/unyt/_on_demand_imports.py
@@ -5,7 +5,6 @@ A set of convenient on-demand imports
 import sys
 from functools import wraps
 from importlib.util import find_spec
-from typing import Type
 
 
 class NotAModule:
@@ -50,7 +49,7 @@ class NotAModule:
 
 
 class OnDemand:
-    _default_factory: Type[NotAModule] = NotAModule
+    _default_factory: type[NotAModule] = NotAModule
 
     def __init_subclass__(cls):
         if not cls.__name__.endswith("_imports"):


### PR DESCRIPTION
This PR drops support for Python 3.8 and updates support for associated packages.

@neutrinoceros when we dropped support for versions 3.6 and 3.7 you came up with a list of minimal versions for other packages--how did you do that? 