### PR TITLE
BUG: fix an issue where array functions would crash (AttributeError) when passed non-ndarray array like objects (e.g. Python lists)

### DIFF
--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -272,7 +272,7 @@ def test_wrapping_completeness():
     [
         [np.array([1]), [2] * Unit()],
         [np.array([1]), [2] * Unit(registry=UnitRegistry())],
-        # [[1], [2] * Unit()],
+        [[1], [2] * Unit()],
     ],
 )
 def test_unit_validation(arrays):


### PR DESCRIPTION
based on #463, closes #462 

this patch was semi-automated with the following script:
```python
import re
from pathlib import Path

module_file = Path(__file__).parent / "unyt" / "_array_functions.py"

module_file.write_text(
    re.sub(
        r"(?P<varname>[\w_]+)\.view\(np.ndarray\)",
        lambda match: f"np.asarray({match.group('varname')})",
        module_file.read_text(),
    )
)
```