### PR TITLE
BUG: fix backward compatibility for calling np.histogram with implicit range units

### DIFF
--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -146,9 +146,16 @@ def _sanitize_range(_range, units):
         ilim = _range[2 * i : 2 * (i + 1)]
         imin, imax = ilim
         if not (hasattr(imin, "units") and hasattr(imax, "units")):
-            raise TypeError(
-                f"Elements of range must both have a 'units' attribute. Got {_range}"
-            )
+            if len(units) == 1:
+                # allow range to be pure numerical scalars
+                # for backward compatibility with unyt 2.9.5
+                # see https://github.com/yt-project/unyt/issues/465
+                imin *= units[0]
+                imax *= units[0]
+            else:
+                raise TypeError(
+                    f"Elements of range must both have a 'units' attribute. Got {_range}"
+                )
         new_range[i] = imin.to_value(units[i]), imax.to_value(units[i])
     return new_range.squeeze()
 

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -475,6 +475,14 @@ def test_histogram():
     assert bins.units == arr.units
 
 
+def test_histogram_implicit_units():
+    # see https://github.com/yt-project/unyt/issues/465
+    arr = np.random.normal(size=1000) * cm
+    counts, bins = np.histogram(arr, bins=10, range=(arr.min().value, arr.max().value))
+    assert type(counts) is np.ndarray
+    assert bins.units == arr.units
+
+
 def test_histogram2d():
     x = np.random.normal(size=100) * cm
     y = np.random.normal(loc=10, size=100) * s


### PR DESCRIPTION
closes #465