### PR TITLE
BUG: explicitly forbid destructive edits to the default unit registry

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1023,7 +1023,7 @@ In practice, the unit metadata for a unit object is contained in an instance of 
 
   >>> from unyt import g
   >>> g.registry  # doctest: +ELLIPSIS
-  <unyt.unit_registry.UnitRegistry ...>
+  <unyt.unit_registry._NonModifiableUnitRegistry ...>
 
 All the unit objects in the :mod:`unyt` namespace make use of the default unit
 registry, importable as :data:`unyt.unit_registry.default_unit_registry`. This

--- a/unyt/tests/test_unit_registry.py
+++ b/unyt/tests/test_unit_registry.py
@@ -45,6 +45,18 @@ def test_add_modify_error():
     assert ureg["tayne"][:3] == ureg["m"][:3]
 
 
+def test_modify_symbol_from_default_unit_registry():
+    # see https://github.com/yt-project/unyt/issues/473
+    from unyt import km
+    from unyt.unit_object import default_unit_registry
+
+    with pytest.raises(TypeError):
+        default_unit_registry.modify("cm", 10 * km)
+
+    with pytest.raises(TypeError):
+        default_unit_registry.remove("cm")
+
+
 def test_keys():
     ureg = UnitRegistry()
     assert sorted(ureg.keys()) == sorted(ureg.lut.keys())

--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -266,8 +266,18 @@ class UnitRegistry:
         return type(self)(lut=lut)
 
 
+class _NonModifiableUnitRegistry(UnitRegistry):
+    """The class of the default unit registry"""
+
+    def modify(self, symbol, base_value):
+        raise TypeError("Units from unyt's default registry cannot be modified.")
+
+    def remove(self, symbol):
+        raise TypeError("Units from unyt's default registry cannot be removed.")
+
+
 #: The default unit registry
-default_unit_registry = UnitRegistry()
+default_unit_registry = _NonModifiableUnitRegistry()
 
 
 def _lookup_unit_symbol(symbol_str, unit_symbol_lut):


### PR DESCRIPTION
Close #473
