### PR TITLE
(NEP 18) Implement and test array functions new in numpy 2.0

### DIFF
--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -957,6 +957,12 @@ if NUMPY_VERSION < Version("2.0.0dev0"):
         ret_units = a.units
         return np.asfarray._implementation(np.asarray(a), dtype=dtype) * ret_units
 
+elif NUMPY_VERSION >= Version("2.0.0dev0"):
+    # functions that were added in numpy 2.0.0
+    @implements(np.linalg.outer)
+    def linalg_outer(x1, x2, /):
+        return product_helper(x1, x2, out=None, func=np.linalg.outer)
+
 
 # functions with pending deprecations
 if hasattr(np, "trapz"):

--- a/unyt/testing.py
+++ b/unyt/testing.py
@@ -75,7 +75,10 @@ def assert_array_equal_units(x, y, **kwargs):
     from numpy.testing import assert_array_equal
 
     assert_array_equal(x, y, **kwargs)
-    assert getattr(x, "units", NULL_UNIT) == getattr(y, "units", NULL_UNIT)
+    if not (xu := getattr(x, "units", NULL_UNIT)) == (
+        yu := getattr(y, "units", NULL_UNIT)
+    ):
+        raise AssertionError(f"Arguments' units do not match (got {xu} and {yu})")
 
 
 def _process_warning(op, message, warning_class, args=(), kwargs=None):


### PR DESCRIPTION
Fix #481
Leaving as a draft for now as I'm actually *ahead* of numpy nightlies on this one, so it should wait until they catch up. They are expected to drop on Monday.