### PR TITLE
(NEP 18) Implement and test array functions new in numpy 2.0

### DIFF
--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -957,6 +957,12 @@ if NUMPY_VERSION < Version("2.0.0dev0"):
         ret_units = a.units
         return np.asfarray._implementation(np.asarray(a), dtype=dtype) * ret_units
 
+elif NUMPY_VERSION >= Version("2.0.0dev0"):
+    # functions that were added in numpy 2.0.0
+    @implements(np.linalg.outer)
+    def linalg_outer(x1, x2, /):
+        return product_helper(x1, x2, out=None, func=np.linalg.outer)
+
 
 # functions with pending deprecations
 if hasattr(np, "trapz"):

--- a/unyt/testing.py
+++ b/unyt/testing.py
@@ -75,7 +75,10 @@ def assert_array_equal_units(x, y, **kwargs):
     from numpy.testing import assert_array_equal
 
     assert_array_equal(x, y, **kwargs)
-    assert getattr(x, "units", NULL_UNIT) == getattr(y, "units", NULL_UNIT)
+    if not (xu := getattr(x, "units", NULL_UNIT)) == (
+        yu := getattr(y, "units", NULL_UNIT)
+    ):
+        raise AssertionError(f"Arguments' units do not match (got {xu} and {yu})")
 
 
 def _process_warning(op, message, warning_class, args=(), kwargs=None):

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -159,14 +159,20 @@ if NUMPY_VERSION >= Version("2.0.0dev0"):
         np.linalg.cross,
         np.linalg.diagonal,
         np.linalg.matmul,
+        np.linalg.matrix_norm,
+        np.linalg.matrix_transpose,
         np.linalg.svdvals,
         np.linalg.tensordot,
         np.linalg.trace,
+        np.linalg.vecdot,
+        np.linalg.vector_norm,
         np.astype,
+        np.matrix_transpose,
         np.unique_all,
         np.unique_counts,
         np.unique_inverse,
         np.unique_values,
+        np.vecdot,
     }
 
 # Functions for which behaviour is intentionally left to default
@@ -522,6 +528,50 @@ def test_linalg_cross():
 def test_linalg_matmul():
     a = np.eye(3) * cm
     assert_array_equal_units(np.linalg.matmul(a, a), np.matmul(a, a))
+
+
+@pytest.mark.skipif(
+    NUMPY_VERSION < Version("2.0.0dev0"),
+    reason="linalg.matrix_norm is new in numpy 2.0",
+)
+def test_linalg_matrix_norm():
+    a = np.eye(3) * cm
+    assert_array_equal_units(np.linalg.matrix_norm(a), np.linalg.norm(a))
+
+
+@pytest.mark.skipif(
+    NUMPY_VERSION < Version("2.0.0dev0"), reason="matrix_transpose is new in numpy 2.0"
+)
+@pytest.mark.parametrize("namespace", [None, "linalg"])
+def test_matrix_transpose(namespace):
+    if namespace is None:
+        func = np.matrix_transpose
+    else:
+        func = getattr(np, namespace).matrix_transpose
+    a = np.arange(0, 9).reshape(3, 3)
+    assert_array_equal_units(func(a), np.transpose(a))
+
+
+@pytest.mark.skipif(
+    NUMPY_VERSION < Version("2.0.0dev0"), reason="vecdot is new in numpy 2.0"
+)
+@pytest.mark.parametrize("namespace", [None, "linalg"])
+def test_vecdot(namespace):
+    if namespace is None:
+        func = np.vecdot
+    else:
+        func = getattr(np, namespace).vecdot
+    a = np.arange(0, 9)
+    assert_array_equal_units(func(a, a), np.vdot(a, a))
+
+
+@pytest.mark.skipif(
+    NUMPY_VERSION < Version("2.0.0dev0"),
+    reason="linalg.vector_norm is new in numpy 2.0",
+)
+def test_linalg_vector_norm():
+    a = np.arange(0, 9)
+    assert_array_equal_units(np.linalg.vector_norm(a), np.linalg.norm(a))
 
 
 def test_linalg_svd():


### PR DESCRIPTION
Replaces #482, also fixes #481 (even including API that were introduced after #482)