### PR TITLE
TST: avoid installing mpmath pre-releases in bleeding edge CI

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -3,7 +3,7 @@ name: CI (bleeding edge)
 # https://github.com/pandas-dev/pandas/blob/master/.github/workflows/python-dev.yml
 
 # check stability against dev version of Python, numpy, and matplotlib
-# and sympy pre-releases
+# and sympy pre-releases (but avoid pre-releases of sympy's dependencies)
 
 on:
   push:
@@ -44,7 +44,8 @@ jobs:
         python -m pip install --pre numpy --only-binary ":all:" --extra-index \
           https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
         python -m pip install pytest
-        python -m pip install --pre sympy
+        python -m pip install sympy
+        python -m pip install --no-deps --upgrade --pre sympy
 
     - name: Build unyt
       run: python -m pip install --no-build-isolation .


### PR DESCRIPTION
Turns out #489 wasn't sufficient to fix bleeding-edge CI. [Example log](https://github.com/yt-project/unyt/actions/runs/8034078442)

So I dug a little deeper and what's happening is that `mpmath` (which we depend on indirectly via `sympy`) is preparing a new release, [currently in alpha (1.4.0a0)](https://pypi.org/project/mpmath/1.4.0a0/), which breaks `sympy`. It's all being discussed upstream by their respective maintainers (see https://github.com/sympy/sympy/issues/26268 and https://github.com/mpmath/mpmath/issues/704), so there isn't much we can do about it on our side but hope for the best outcome.

While we still want to test against sympy pre-releases, we should probably not care about testing with pre-releases of *its* dependencies (they are doing it already). The way to do that with pip is to install sympy normally then upgrade *just* it with `--upgrade --no-deps --pre`.