### PR TITLE
Add suport for np.cbrt

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -26,6 +26,7 @@ from numpy import (
     bitwise_and,
     bitwise_or,
     bitwise_xor,
+    cbrt,
     ceil,
     clip,
     conj,
@@ -170,6 +171,11 @@ def _iterable(obj):
 @lru_cache(maxsize=128, typed=False)
 def _sqrt_unit(unit):
     return 1, unit**0.5
+
+
+@lru_cache(maxsize=128, typed=False)
+def _cbrt_unit(unit):
+    return 1, unit ** (1.0 / 3.0)
 
 
 @lru_cache(maxsize=128, typed=False)
@@ -339,6 +345,7 @@ unary_operators = (
     expm1,
     log1p,
     sqrt,
+    cbrt,
     square,
     reciprocal,
     sin,
@@ -504,6 +511,7 @@ class unyt_array(np.ndarray):
         expm1: _return_without_unit,
         log1p: _return_without_unit,
         sqrt: _sqrt_unit,
+        cbrt: _cbrt_unit,
         square: _square_unit,
         reciprocal: _reciprocal_unit,
         sin: _return_without_unit,

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -973,7 +973,9 @@ def unary_ufunc_comparison(ufunc, a):
         assert_array_equal(ret, out)
         assert_array_equal(ret.to_ndarray(), ufunc(a_array))
         assert ret.units == out.units
-    elif ufunc in yield_np_ufuncs(["ones_like", "square", "sqrt", "reciprocal"]):
+    elif ufunc in yield_np_ufuncs(
+        ["ones_like", "square", "sqrt", "cbrt", "reciprocal"]
+    ):
         if ufunc is np.ones_like:
             ret = ufunc(a)
         else:
@@ -989,6 +991,9 @@ def unary_ufunc_comparison(ufunc, a):
         elif ufunc is np.sqrt:
             assert out.units == a.units**0.5
             assert ret.units == a.units**0.5
+        elif ufunc is np.cbrt:
+            assert out.units == a.units ** (1.0 / 3.0)
+            assert ret.units == a.units ** (1.0 / 3.0)
         elif ufunc is np.reciprocal:
             assert out.units == a.units**-1
             assert ret.units == a.units**-1
@@ -1056,6 +1061,7 @@ def unary_ufunc_comparison(ufunc, a):
             "ones_like",
             "square",
             "sqrt",
+            "cbrt",
             "reciprocal",
             "invert",
             "isnat",


### PR DESCRIPTION
Hi,

I noticed that currently `np.cbrt` is not supported on unyt arrays. (Getting `KeyError: <ufunc 'cbrt'>` at `unyt/array.py:1814, in unyt_array.__array_ufunc__(self, ufunc, method, *inputs, **kwargs)`)

This very small pull request adds that. I basically copied what was done for np.sqrt.

I extended the relevant unit test in `unyt/tests/test_unyt_array.py` and I don't think this part of `unyt` is documented, so I didn't add any documentation.