### PR TITLE
MNT: use macOS x86 for Python 3.9 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
           - '3.12'
         # Test all on ubuntu, test ends on macos and windows
         include:
-          - os: macos-latest
+          - os: macos-12
+            # pin macos-12 (x86) because Python 3.9 is broken in the arm64 image
             python-version: '3.9'
           - os: windows-latest
             python-version: '3.9'


### PR DESCRIPTION
Context: [`macos-latest` is being migrated repo-by-repo from `macos-12` (x86) to `macos-14` (arm64)](https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/)
It appears that this migration was rolled out for unyt 3 days ago. As a result, regular CI is broken on macOS+py39, presumably because of a faulty docker image. No test is failing, but jobs are still reported as failed. Pinning to an 'old' macOS image seems appropriate here and fixes the immediate problem.