### PR TITLE
DOC: adjust doctests to changes in array repr from numpy 2.0

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1494,7 +1494,7 @@ Methods that hang off of a :mod:`unyt_dask_array` object and operations on
 One important caveat is that using Dask array functions may strip units:
 
     >>> da.sum(x_da).compute()
-    49995000
+    np.int64(49995000)
 
 For simple reductions, you can use the :mod:`reduce_with_units` function:
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     pytest
     h5py
     pint
-    astropy!=6.1.1
+    !py39: astropy!=6.1.1
     coverage[toml]>=5.0
     pytest-cov
     pytest-doctestplus

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ depends = begin
 deps =
     pytest
     h5py
-    pint
+    !py39: pint
     !py39: astropy!=6.1.1
     coverage[toml]>=5.0
     pytest-cov
@@ -30,6 +30,14 @@ deps =
     dask[array,diagnostics]
 commands =
     pytest --cov=unyt --cov-append --doctest-modules --doctest-plus --doctest-rst --basetemp={envtmpdir}
+    coverage report --omit='.tox/*'
+
+[testenv:py39]
+# skip doctest on py39 because doctests require numpy>=2.0 and all optional deps,
+# but some of our optional deps (pint, astropy) don't have a version that support
+# both numpy>=2.0 and Python 3.9
+commands=
+    pytest --cov=unyt --cov-append --basetemp={envtmpdir}
     coverage report --omit='.tox/*'
 
 [testenv:py39-versions]

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     pytest
     h5py
     pint
-    astropy
+    astropy!=6.1.1
     coverage[toml]>=5.0
     pytest-cov
     pytest-doctestplus

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1255,7 +1255,7 @@ class unyt_array(np.ndarray):
         >>> from unyt import km
         >>> data = [3, 8, 7]*km
         >>> print(np.argsort(data))
-        [0 2 1]
+        [0 2 1] km
         >>> print(data.argsort())
         [0 2 1]
         """


### PR DESCRIPTION
A couple non-user facing adjustments to numpy 2.0

[example logs](https://github.com/yt-project/unyt/actions/runs/9540016330/job/26291141524)