### PR TITLE
TST: enable doctests in bleeding-edge CI

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -43,7 +43,7 @@ jobs:
         python -m pip install --upgrade setuptools wheel setuptools_scm
         python -m pip install --pre numpy --only-binary ":all:" --extra-index \
           https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-        python -m pip install pytest
+        python -m pip install pytest pytest-doctestplus docutils
         python -m pip install sympy
         python -m pip install --no-deps --upgrade --pre sympy
 
@@ -53,4 +53,4 @@ jobs:
     - run: python -m pip list
 
     - name: Run Tests
-      run: pytest -vvv unyt/
+      run: pytest -vvv --doctest-modules --doctest-plus --doctest-rst unyt/


### PR DESCRIPTION
NumPy 2.1 was just released and appears to break a bunch of doctests and I didn't this that coming. With this patch, this could be caught in advance next time. I'll try fixing the issue too but maybe that'll be a different PR depending on how heavy the fix.
Also note that problems solved in #512 will also fail CI here.