### PR TITLE
TST: add CPython 3.13 to regular test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
         # Test all on ubuntu, test ends on macos and windows
         include:
           - os: macos-13
@@ -30,9 +31,9 @@ jobs:
           - os: windows-latest
             python-version: '3.9'
           - os: macos-latest
-            python-version: '3.12'
+            python-version: '3.13'
           - os: windows-latest
-            python-version: '3.12'
+            python-version: '3.13'
 
 
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39-docs,begin,py39-dependencies,py39-versions,py{39,310,311,312},py39-unyt-module-test-function,end
+envlist = py39-docs,begin,py39-dependencies,py39-versions,py{39,310,311,312,313},py39-unyt-module-test-function,end
 isolated_build = True
 
 [gh-actions]
@@ -8,6 +8,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv]
 package = wheel


### PR DESCRIPTION
blocked by:
- https://github.com/hgrecco/pint/issues/1969
