### PR TITLE
MNT: switch Python 3.9 + mac testing from macos-12 to macos-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
           - '3.12'
         # Test all on ubuntu, test ends on macos and windows
         include:
-          - os: macos-12
-            # pin macos-12 (x86) because Python 3.9 is broken in the arm64 image
+          - os: macos-13
+            # pin macos-13 (x86) because Python 3.9 is broken in the arm64 image
             python-version: '3.9'
           - os: windows-latest
             python-version: '3.9'


### PR DESCRIPTION
Following the upcoming deprecation of this runner image https://github.com/actions/runner-images/issues/10721