### PR TITLE
Prod bugfix

### DIFF
--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -535,7 +535,8 @@ def copyto(dst, src, *args, **kwargs):
 
 @implements(np.prod)
 def prod(a, *args, **kwargs):
-    return np.prod._implementation(np.asarray(a), *args, **kwargs) * a.units**a.size
+    res = np.prod._implementation(np.asarray(a), *args, **kwargs)
+    return res * a.units**(a.size // res.size)
 
 
 @implements(np.var)

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -1291,6 +1291,17 @@ def test_scalar_reducer(func, expected_units):
     assert y.units == expected_units
 
 
+def test_prod_with_axis():
+    x = [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+    ] * cm
+    y = np.prod(x, axis=0)
+    assert type(y) is unyt_array
+    assert y.units == cm ** 3
+
+
 @pytest.mark.parametrize(
     "func",
     [


### PR DESCRIPTION
Closes #536 

When an `axis` keyword is passed to `np.prod`, the power that the dimensions should be raised to are not the size of the array but the ratio of the sizes of the input array and returned array (it's always this, but without the kwarg the size of the returned array is 1).