### PR TITLE
BUG: `np.histogram*` functions give correct units when `weights` and/or `density` are set

### DIFF
--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -202,7 +202,9 @@ def histogram2d(x, y, bins=10, range=None, density=None, weights=None, *args, **
 
 
 @implements(np.histogramdd)
-def histogramdd(sample, bins=10, range=None, density=None, weights=None, *args, **kwargs):
+def histogramdd(
+    sample, bins=10, range=None, density=None, weights=None, *args, **kwargs
+):
     units = [_.units for _ in sample]
     range = _sanitize_range(range, units=units)
     counts, bins = np.histogramdd._implementation(

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -692,8 +692,9 @@ def nanquantile(a, *args, **kwargs):
 
 @implements(np.linalg.det)
 def linalg_det(a, *args, **kwargs):
-    return np.linalg.det._implementation(np.asarray(a), *args, **kwargs) * a.units ** (
-        a.shape[0]
+    return (
+        np.linalg.det._implementation(np.asarray(a), *args, **kwargs)
+        * a.units ** (a.shape[0])
     )
 
 

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -160,7 +160,7 @@ def _sanitize_range(_range, units):
 
 def _histogram(a, bins=10, range=None, density=None, weights=None, normed=None):
     range = _sanitize_range(range, units=[a.units])
-    if NUMPY_VERSION > Version("1.23"):
+    if NUMPY_VERSION >= Version("1.24"):
         counts, bins = np.histogram._implementation(
             np.asarray(a),
             bins=bins,
@@ -187,7 +187,7 @@ def _histogram(a, bins=10, range=None, density=None, weights=None, normed=None):
     return counts, bins * a.units
 
 
-if NUMPY_VERSION > Version("1.23"):
+if NUMPY_VERSION >= Version("1.24"):
 
     @implements(np.histogram)
     def histogram(a, bins=10, range=None, density=None, weights=None):
@@ -204,7 +204,7 @@ else:
 
 def _histogram2d(x, y, bins=10, range=None, density=None, weights=None, normed=None):
     range = _sanitize_range(range, units=[x.units, y.units])
-    if NUMPY_VERSION > Version("1.23"):
+    if NUMPY_VERSION >= Version("1.24"):
         counts, xbins, ybins = np.histogram2d._implementation(
             np.asarray(x),
             np.asarray(y),
@@ -236,7 +236,7 @@ def _histogram2d(x, y, bins=10, range=None, density=None, weights=None, normed=N
     return counts, xbins * x.units, ybins * y.units
 
 
-if NUMPY_VERSION > Version("1.23"):
+if NUMPY_VERSION >= Version("1.24"):
 
     @implements(np.histogram2d)
     def histogram2d(x, y, bins=10, range=None, density=None, weights=None):
@@ -262,7 +262,7 @@ else:
 def _histogramdd(sample, bins=10, range=None, density=None, weights=None, normed=None):
     units = [getattr(_, "units", NULL_UNIT) for _ in sample]
     range = _sanitize_range(range, units=units)
-    if NUMPY_VERSION > Version("1.23"):
+    if NUMPY_VERSION >= Version("1.24"):
         counts, bins = np.histogramdd._implementation(
             [np.asarray(_) for _ in sample],
             bins=bins,
@@ -291,7 +291,7 @@ def _histogramdd(sample, bins=10, range=None, density=None, weights=None, normed
     return counts, tuple(_bin * u for _bin, u in zip(bins, units))
 
 
-if NUMPY_VERSION > Version("1.23"):
+if NUMPY_VERSION >= Version("1.24"):
 
     @implements(np.histogramdd)
     def histogramdd(sample, bins=10, range=None, density=None, weights=None):

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -158,7 +158,7 @@ def _sanitize_range(_range, units):
     return new_range.squeeze()
 
 
-def _histogram(a, bins=10, range=None, density=None, weights=None, normed=None):
+def _histogram(a, *, bins=10, range=None, density=None, weights=None, normed=None):
     range = _sanitize_range(range, units=[getattr(a, "units", None)])
     if NUMPY_VERSION >= Version("1.24"):
         counts, bins = np.histogram._implementation(
@@ -202,7 +202,7 @@ else:
         )
 
 
-def _histogram2d(x, y, bins=10, range=None, density=None, weights=None, normed=None):
+def _histogram2d(x, y, *, bins=10, range=None, density=None, weights=None, normed=None):
     range = _sanitize_range(
         range, units=[getattr(x, "units", None), getattr(y, "units", None)]
     )
@@ -261,7 +261,9 @@ else:
         )
 
 
-def _histogramdd(sample, bins=10, range=None, density=None, weights=None, normed=None):
+def _histogramdd(
+    sample, *, bins=10, range=None, density=None, weights=None, normed=None
+):
     range = _sanitize_range(range, units=[getattr(_, "units", None) for _ in sample])
     if NUMPY_VERSION >= Version("1.24"):
         counts, bins = np.histogramdd._implementation(
@@ -692,9 +694,8 @@ def nanquantile(a, *args, **kwargs):
 
 @implements(np.linalg.det)
 def linalg_det(a, *args, **kwargs):
-    return (
-        np.linalg.det._implementation(np.asarray(a), *args, **kwargs)
-        * a.units ** (a.shape[0])
+    return np.linalg.det._implementation(np.asarray(a), *args, **kwargs) * a.units ** (
+        a.shape[0]
     )
 
 

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -694,8 +694,9 @@ def nanquantile(a, *args, **kwargs):
 
 @implements(np.linalg.det)
 def linalg_det(a, *args, **kwargs):
-    return np.linalg.det._implementation(np.asarray(a), *args, **kwargs) * a.units ** (
-        a.shape[0]
+    return (
+        np.linalg.det._implementation(np.asarray(a), *args, **kwargs)
+        * a.units ** (a.shape[0])
     )
 
 

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -667,15 +667,15 @@ def test_histogram_with_weights_density():
     # check case with density
     rng = np.random.default_rng()
     arr = rng.normal(size=1000) * cm
-    density, bins = np.histogram(arr, bins=10, range=(arr.min(), arr.max()), density=True)
+    density, bins = np.histogram(
+        arr, bins=10, range=(arr.min(), arr.max()), density=True
+    )
     assert type(density) is unyt_array
-    assert density.units == arr.units ** -1
+    assert density.units == arr.units**-1
     assert bins.units == arr.units
     # also check case with weights
     w = rng.uniform(size=1000) * g
-    wcounts, wbins = np.histogram(
-        arr, bins=10, range=(arr.min(), arr.max()), weights=w
-    )
+    wcounts, wbins = np.histogram(arr, bins=10, range=(arr.min(), arr.max()), weights=w)
     assert type(wcounts) is unyt_array
     assert wcounts.units == w.units
     assert wbins.units == arr.units
@@ -761,7 +761,9 @@ def test_histogramdd_with_weights_density():
     assert ywbins.units == y.units
     assert zwbins.units == z.units
     # also check case with weights and density
-    wdensity, (xwdbins, ywdbins, zwdbins) = np.histogramdd((x, y, z), weights=w, density=True)
+    wdensity, (xwdbins, ywdbins, zwdbins) = np.histogramdd(
+        (x, y, z), weights=w, density=True
+    )
     assert wdensity.ndim == 3
     assert type(wdensity) is unyt_array
     assert wdensity.units == w.units / (x.units * y.units * z.units)

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -686,6 +686,11 @@ def test_histogram_with_weights_density():
     assert type(wdensity) is unyt_array
     assert wdensity.units == w.units / arr.units
     assert wdbins.units == arr.units
+    # also check case where only weights have units
+    wcounts2, wbins2 = np.histogram(arr.to_value(arr.units), weights=w)
+    assert type(wcounts2) is unyt_array
+    assert wcounts2.units == w.units
+    assert not hasattr(wbins2, "units")
 
 
 def test_histogram2d():
@@ -724,6 +729,14 @@ def test_histogram2d_with_weights_density():
     assert wdensity.units == w.units / (x.units * y.units)
     assert xwdbins.units == x.units
     assert ywdbins.units == y.units
+    # also check case where only weights have units
+    wcounts2, xwbins2, ywbins2 = np.histogram2d(
+        x.to_value(x.units), y.to_value(y.units), weights=w
+    )
+    assert type(wcounts2) is unyt_array
+    assert wcounts2.units == w.units
+    assert not hasattr(xwbins2, "units")
+    assert not hasattr(ywbins2, "units")
 
 
 def test_histogramdd():
@@ -770,6 +783,15 @@ def test_histogramdd_with_weights_density():
     assert xwdbins.units == x.units
     assert ywdbins.units == y.units
     assert zwdbins.units == z.units
+    # also check case where only weights have units
+    wcounts2, (xwbins2, ywbins2, zwbins2) = np.histogramdd(
+        (x.to_value(x.units), y.to_value(y.units), z.to_value(z.units)), weights=w
+    )
+    assert type(wcounts2) is unyt_array
+    assert wcounts2.units == w.units
+    assert not hasattr(xwbins2, "units")
+    assert not hasattr(ywbins2, "units")
+    assert not hasattr(zwbins2, "units")
 
 
 def test_histogram_bin_edges():

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -663,6 +663,31 @@ def test_histogram_implicit_units():
     assert bins.units == arr.units
 
 
+def test_histogram_with_weights_density():
+    # check case with density
+    rng = np.random.default_rng()
+    arr = rng.normal(size=1000) * cm
+    density, bins = np.histogram(arr, bins=10, range=(arr.min(), arr.max()), density=True)
+    assert type(density) is unyt_array
+    assert density.units == arr.units ** -1
+    assert bins.units == arr.units
+    # also check case with weights
+    w = rng.uniform(size=1000) * g
+    wcounts, wbins = np.histogram(
+        arr, bins=10, range=(arr.min(), arr.max()), weights=w
+    )
+    assert type(wcounts) is unyt_array
+    assert wcounts.units == w.units
+    assert wbins.units == arr.units
+    # also check case with weights and density
+    wdensity, wdbins = np.histogram(
+        arr, bins=10, range=(arr.min(), arr.max()), density=True, weights=w
+    )
+    assert type(wdensity) is unyt_array
+    assert wdensity.units == w.units / arr.units
+    assert wdbins.units == arr.units
+
+
 def test_histogram2d():
     rng = np.random.default_rng()
     x = rng.normal(size=100) * cm
@@ -671,6 +696,34 @@ def test_histogram2d():
     assert counts.ndim == 2
     assert xbins.units == x.units
     assert ybins.units == y.units
+
+
+def test_histogram2d_with_weights_density():
+    # check case with density
+    rng = np.random.default_rng()
+    x = rng.normal(size=100) * cm
+    y = rng.normal(loc=10, size=100) * s
+    density, xbins, ybins = np.histogram2d(x, y, density=True)
+    assert density.ndim == 2
+    assert type(density) is unyt_array
+    assert density.units == (x.units * y.units) ** -1
+    assert xbins.units == x.units
+    assert ybins.units == y.units
+    # also check case with weights
+    w = rng.uniform(size=100) * g
+    wcounts, xwbins, ywbins = np.histogram2d(x, y, weights=w)
+    assert wcounts.ndim == 2
+    assert type(wcounts) is unyt_array
+    assert wcounts.units == w.units
+    assert xwbins.units == x.units
+    assert ywbins.units == y.units
+    # also check case with weights and density
+    wdensity, xwdbins, ywdbins = np.histogram2d(x, y, weights=w, density=True)
+    assert wdensity.ndim == 2
+    assert type(wdensity) is unyt_array
+    assert wdensity.units == w.units / (x.units * y.units)
+    assert xwdbins.units == x.units
+    assert ywdbins.units == y.units
 
 
 def test_histogramdd():
@@ -683,6 +736,38 @@ def test_histogramdd():
     assert xbins.units == x.units
     assert ybins.units == y.units
     assert zbins.units == z.units
+
+
+def test_histogramdd_with_weights_density():
+    # check case with density
+    rng = np.random.default_rng()
+    x = rng.normal(size=100) * cm
+    y = rng.normal(loc=10, size=100) * s
+    z = rng.normal(size=100) * g
+    density, (xbins, ybins, zbins) = np.histogramdd((x, y, z), density=True)
+    assert density.ndim == 3
+    assert type(density) is unyt_array
+    assert density.units == (x.units * y.units * z.units) ** -1
+    assert xbins.units == x.units
+    assert ybins.units == y.units
+    assert zbins.units == z.units
+    # also check case with weights
+    w = rng.uniform(size=100) * K
+    wcounts, (xwbins, ywbins, zwbins) = np.histogramdd((x, y, z), weights=w)
+    assert wcounts.ndim == 3
+    assert type(wcounts) is unyt_array
+    assert wcounts.units == w.units
+    assert xwbins.units == x.units
+    assert ywbins.units == y.units
+    assert zwbins.units == z.units
+    # also check case with weights and density
+    wdensity, (xwdbins, ywdbins, zwdbins) = np.histogramdd((x, y, z), weights=w, density=True)
+    assert wdensity.ndim == 3
+    assert type(wdensity) is unyt_array
+    assert wdensity.units == w.units / (x.units * y.units * z.units)
+    assert xwdbins.units == x.units
+    assert ywdbins.units == y.units
+    assert zwdbins.units == z.units
 
 
 def test_histogram_bin_edges():

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -646,160 +646,197 @@ def test_linalg_tensordot():
     assert_array_equal_units(res, ref)
 
 
-def test_histogram():
-    rng = np.random.default_rng()
-    arr = rng.normal(size=1000) * cm
-    counts, bins = np.histogram(arr, bins=10, range=(arr.min(), arr.max()))
-    assert type(counts) is np.ndarray
-    assert bins.units == arr.units
+class TestHistograms:
+    def test_histogram(self):
+        rng = np.random.default_rng()
+        arr = rng.normal(size=1000) * cm
+        counts, bins = np.histogram(arr, bins=10, range=(arr.min(), arr.max()))
+        assert type(counts) is np.ndarray
+        assert bins.units == arr.units
 
+    def test_histogram_implicit_units(self):
+        # see https://github.com/yt-project/unyt/issues/465
+        rng = np.random.default_rng()
+        arr = rng.normal(size=1000) * cm
+        counts, bins = np.histogram(
+            arr, bins=10, range=(arr.min().value, arr.max().value)
+        )
+        assert type(counts) is np.ndarray
+        assert bins.units == arr.units
 
-def test_histogram_implicit_units():
-    # see https://github.com/yt-project/unyt/issues/465
-    rng = np.random.default_rng()
-    arr = rng.normal(size=1000) * cm
-    counts, bins = np.histogram(arr, bins=10, range=(arr.min().value, arr.max().value))
-    assert type(counts) is np.ndarray
-    assert bins.units == arr.units
+    def test_histogram_with_density(self):
+        rng = np.random.default_rng()
+        arr = rng.normal(size=1000) * cm
+        density, bins = np.histogram(
+            arr, bins=10, range=(arr.min(), arr.max()), density=True
+        )
+        assert type(density) is unyt_array
+        assert density.units == arr.units**-1
+        assert bins.units == arr.units
 
+    def test_histogram_with_weights(self):
+        rng = np.random.default_rng()
+        arr = rng.normal(size=1000) * cm
+        w = rng.uniform(size=1000) * g
+        wcounts, wbins = np.histogram(
+            arr, bins=10, range=(arr.min(), arr.max()), weights=w
+        )
+        assert type(wcounts) is unyt_array
+        assert wcounts.units == w.units
+        assert wbins.units == arr.units
 
-def test_histogram_with_weights_density():
-    # check case with density
-    rng = np.random.default_rng()
-    arr = rng.normal(size=1000) * cm
-    density, bins = np.histogram(
-        arr, bins=10, range=(arr.min(), arr.max()), density=True
-    )
-    assert type(density) is unyt_array
-    assert density.units == arr.units**-1
-    assert bins.units == arr.units
-    # also check case with weights
-    w = rng.uniform(size=1000) * g
-    wcounts, wbins = np.histogram(arr, bins=10, range=(arr.min(), arr.max()), weights=w)
-    assert type(wcounts) is unyt_array
-    assert wcounts.units == w.units
-    assert wbins.units == arr.units
-    # also check case with weights and density
-    wdensity, wdbins = np.histogram(
-        arr, bins=10, range=(arr.min(), arr.max()), density=True, weights=w
-    )
-    assert type(wdensity) is unyt_array
-    assert wdensity.units == w.units / arr.units
-    assert wdbins.units == arr.units
-    # also check case where only weights have units
-    wcounts2, wbins2 = np.histogram(arr.to_value(arr.units), weights=w)
-    assert type(wcounts2) is unyt_array
-    assert wcounts2.units == w.units
-    assert not hasattr(wbins2, "units")
+    def test_histogram_with_weights_and_density(self):
+        rng = np.random.default_rng()
+        arr = rng.normal(size=1000) * cm
+        w = rng.uniform(size=1000) * g
+        wdensity, wdbins = np.histogram(
+            arr, bins=10, range=(arr.min(), arr.max()), density=True, weights=w
+        )
+        assert type(wdensity) is unyt_array
+        assert wdensity.units == w.units / arr.units
+        assert wdbins.units == arr.units
 
+    def test_histogram_with_weights_and_dimless_arr(self):
+        rng = np.random.default_rng()
+        arr = rng.normal(size=1000) * cm
+        w = rng.uniform(size=1000) * g
+        wcounts2, wbins2 = np.histogram(arr.to_value(arr.units), weights=w)
+        assert type(wcounts2) is unyt_array
+        assert wcounts2.units == w.units
+        assert not hasattr(wbins2, "units")
 
-def test_histogram2d():
-    rng = np.random.default_rng()
-    x = rng.normal(size=100) * cm
-    y = rng.normal(loc=10, size=100) * s
-    counts, xbins, ybins = np.histogram2d(x, y)
-    assert counts.ndim == 2
-    assert xbins.units == x.units
-    assert ybins.units == y.units
+    def test_histogram2d(self):
+        rng = np.random.default_rng()
+        x = rng.normal(size=100) * cm
+        y = rng.normal(loc=10, size=100) * s
+        counts, xbins, ybins = np.histogram2d(x, y)
+        assert counts.ndim == 2
+        assert xbins.units == x.units
+        assert ybins.units == y.units
 
+    def test_histogram2d_with_density(self):
+        rng = np.random.default_rng()
+        x = rng.normal(size=100) * cm
+        y = rng.normal(loc=10, size=100) * s
+        density, xbins, ybins = np.histogram2d(x, y, density=True)
+        assert density.ndim == 2
+        assert type(density) is unyt_array
+        assert density.units == (x.units * y.units) ** -1
+        assert xbins.units == x.units
+        assert ybins.units == y.units
 
-def test_histogram2d_with_weights_density():
-    # check case with density
-    rng = np.random.default_rng()
-    x = rng.normal(size=100) * cm
-    y = rng.normal(loc=10, size=100) * s
-    density, xbins, ybins = np.histogram2d(x, y, density=True)
-    assert density.ndim == 2
-    assert type(density) is unyt_array
-    assert density.units == (x.units * y.units) ** -1
-    assert xbins.units == x.units
-    assert ybins.units == y.units
-    # also check case with weights
-    w = rng.uniform(size=100) * g
-    wcounts, xwbins, ywbins = np.histogram2d(x, y, weights=w)
-    assert wcounts.ndim == 2
-    assert type(wcounts) is unyt_array
-    assert wcounts.units == w.units
-    assert xwbins.units == x.units
-    assert ywbins.units == y.units
-    # also check case with weights and density
-    wdensity, xwdbins, ywdbins = np.histogram2d(x, y, weights=w, density=True)
-    assert wdensity.ndim == 2
-    assert type(wdensity) is unyt_array
-    assert wdensity.units == w.units / (x.units * y.units)
-    assert xwdbins.units == x.units
-    assert ywdbins.units == y.units
-    # also check case where only weights have units
-    wcounts2, xwbins2, ywbins2 = np.histogram2d(
-        x.to_value(x.units), y.to_value(y.units), weights=w
-    )
-    assert type(wcounts2) is unyt_array
-    assert wcounts2.units == w.units
-    assert not hasattr(xwbins2, "units")
-    assert not hasattr(ywbins2, "units")
+    def test_histogram2d_with_weights(self):
+        rng = np.random.default_rng()
+        x = rng.normal(size=100) * cm
+        y = rng.normal(loc=10, size=100) * s
+        w = rng.uniform(size=100) * g
+        wcounts, xwbins, ywbins = np.histogram2d(x, y, weights=w)
+        assert wcounts.ndim == 2
+        assert type(wcounts) is unyt_array
+        assert wcounts.units == w.units
+        assert xwbins.units == x.units
+        assert ywbins.units == y.units
 
+    def test_histogram2d_with_weights_and_density(self):
+        rng = np.random.default_rng()
+        x = rng.normal(size=100) * cm
+        y = rng.normal(loc=10, size=100) * s
+        w = rng.uniform(size=100) * g
+        wdensity, xwdbins, ywdbins = np.histogram2d(x, y, weights=w, density=True)
+        assert wdensity.ndim == 2
+        assert type(wdensity) is unyt_array
+        assert wdensity.units == w.units / (x.units * y.units)
+        assert xwdbins.units == x.units
+        assert ywdbins.units == y.units
 
-def test_histogramdd():
-    rng = np.random.default_rng()
-    x = rng.normal(size=100) * cm
-    y = rng.normal(size=100) * s
-    z = rng.normal(size=100) * g
-    counts, (xbins, ybins, zbins) = np.histogramdd((x, y, z))
-    assert counts.ndim == 3
-    assert xbins.units == x.units
-    assert ybins.units == y.units
-    assert zbins.units == z.units
+    def test_histogram2d_with_weights_and_dimless_arr(self):
+        rng = np.random.default_rng()
+        x = rng.normal(size=100) * cm
+        y = rng.normal(loc=10, size=100) * s
+        w = rng.uniform(size=100) * g
+        wcounts2, xwbins2, ywbins2 = np.histogram2d(
+            x.to_value(x.units), y.to_value(y.units), weights=w
+        )
+        assert type(wcounts2) is unyt_array
+        assert wcounts2.units == w.units
+        assert not hasattr(xwbins2, "units")
+        assert not hasattr(ywbins2, "units")
 
+    def test_histogramdd(self):
+        rng = np.random.default_rng()
+        x = rng.normal(size=100) * cm
+        y = rng.normal(size=100) * s
+        z = rng.normal(size=100) * g
+        counts, (xbins, ybins, zbins) = np.histogramdd((x, y, z))
+        assert counts.ndim == 3
+        assert xbins.units == x.units
+        assert ybins.units == y.units
+        assert zbins.units == z.units
 
-def test_histogramdd_with_weights_density():
-    # check case with density
-    rng = np.random.default_rng()
-    x = rng.normal(size=100) * cm
-    y = rng.normal(loc=10, size=100) * s
-    z = rng.normal(size=100) * g
-    density, (xbins, ybins, zbins) = np.histogramdd((x, y, z), density=True)
-    assert density.ndim == 3
-    assert type(density) is unyt_array
-    assert density.units == (x.units * y.units * z.units) ** -1
-    assert xbins.units == x.units
-    assert ybins.units == y.units
-    assert zbins.units == z.units
-    # also check case with weights
-    w = rng.uniform(size=100) * K
-    wcounts, (xwbins, ywbins, zwbins) = np.histogramdd((x, y, z), weights=w)
-    assert wcounts.ndim == 3
-    assert type(wcounts) is unyt_array
-    assert wcounts.units == w.units
-    assert xwbins.units == x.units
-    assert ywbins.units == y.units
-    assert zwbins.units == z.units
-    # also check case with weights and density
-    wdensity, (xwdbins, ywdbins, zwdbins) = np.histogramdd(
-        (x, y, z), weights=w, density=True
-    )
-    assert wdensity.ndim == 3
-    assert type(wdensity) is unyt_array
-    assert wdensity.units == w.units / (x.units * y.units * z.units)
-    assert xwdbins.units == x.units
-    assert ywdbins.units == y.units
-    assert zwdbins.units == z.units
-    # also check case where only weights have units
-    wcounts2, (xwbins2, ywbins2, zwbins2) = np.histogramdd(
-        (x.to_value(x.units), y.to_value(y.units), z.to_value(z.units)), weights=w
-    )
-    assert type(wcounts2) is unyt_array
-    assert wcounts2.units == w.units
-    assert not hasattr(xwbins2, "units")
-    assert not hasattr(ywbins2, "units")
-    assert not hasattr(zwbins2, "units")
+    def test_histogramdd_with_density(self):
+        rng = np.random.default_rng()
+        x = rng.normal(size=100) * cm
+        y = rng.normal(loc=10, size=100) * s
+        z = rng.normal(size=100) * g
+        density, (xbins, ybins, zbins) = np.histogramdd((x, y, z), density=True)
+        assert density.ndim == 3
+        assert type(density) is unyt_array
+        assert density.units == (x.units * y.units * z.units) ** -1
+        assert xbins.units == x.units
+        assert ybins.units == y.units
+        assert zbins.units == z.units
 
+    def test_histogramdd_with_weights(self):
+        rng = np.random.default_rng()
+        x = rng.normal(size=100) * cm
+        y = rng.normal(loc=10, size=100) * s
+        z = rng.normal(size=100) * g
+        w = rng.uniform(size=100) * K
+        wcounts, (xwbins, ywbins, zwbins) = np.histogramdd((x, y, z), weights=w)
+        assert wcounts.ndim == 3
+        assert type(wcounts) is unyt_array
+        assert wcounts.units == w.units
+        assert xwbins.units == x.units
+        assert ywbins.units == y.units
+        assert zwbins.units == z.units
 
-def test_histogram_bin_edges():
-    rng = np.random.default_rng()
-    arr = rng.normal(size=1000) * cm
-    bins = np.histogram_bin_edges(arr)
-    assert type(bins) is unyt_array
-    assert bins.units == arr.units
+    def test_histogramdd_with_weights_and_density(self):
+        rng = np.random.default_rng()
+        x = rng.normal(size=100) * cm
+        y = rng.normal(loc=10, size=100) * s
+        z = rng.normal(size=100) * g
+        w = rng.uniform(size=100) * K
+        wdensity, (xwdbins, ywdbins, zwdbins) = np.histogramdd(
+            (x, y, z), weights=w, density=True
+        )
+        assert wdensity.ndim == 3
+        assert type(wdensity) is unyt_array
+        assert wdensity.units == w.units / (x.units * y.units * z.units)
+        assert xwdbins.units == x.units
+        assert ywdbins.units == y.units
+        assert zwdbins.units == z.units
+
+    def test_histogramdd_with_weights_and_dimless_arr(self):
+        rng = np.random.default_rng()
+        x = rng.normal(size=100) * cm
+        y = rng.normal(loc=10, size=100) * s
+        z = rng.normal(size=100) * g
+        w = rng.uniform(size=100) * K
+        wcounts2, (xwbins2, ywbins2, zwbins2) = np.histogramdd(
+            (x.to_value(x.units), y.to_value(y.units), z.to_value(z.units)), weights=w
+        )
+        assert type(wcounts2) is unyt_array
+        assert wcounts2.units == w.units
+        assert not hasattr(xwbins2, "units")
+        assert not hasattr(ywbins2, "units")
+        assert not hasattr(zwbins2, "units")
+
+    def test_histogram_bin_edges(self):
+        rng = np.random.default_rng()
+        arr = rng.normal(size=1000) * cm
+        bins = np.histogram_bin_edges(arr)
+        assert type(bins) is unyt_array
+        assert bins.units == arr.units
 
 
 def test_concatenate():


### PR DESCRIPTION
Closes #538 

When `weights` are given to a histogram function the histogram should inherit the units of the weights. When `density=True` is set, the histogram should have the inverse units of each dimension of the input applied.