### PR TITLE
BUG: `linspace` and `logspace` give incorrect results or crash with some inputs

### DIFF
--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -649,10 +649,44 @@ def _linspace(
         return result * start.units
 
 
-# Because signature changed (new kwarg `device`) in 2.0.0:
-@implements(np.linspace)
-def linspace(*args, **kwargs):
-    return _linspace(*args, **kwargs)
+if NUMPY_VERSION >= Version("2.1.0.dev0"):
+
+    @implements(np.linspace)
+    def linspace(
+        start,
+        stop,
+        num=50,
+        endpoint=True,
+        retstep=False,
+        dtype=None,
+        axis=0,
+        *,
+        device=None,
+    ):
+        return _linspace(
+            start,
+            stop,
+            num=50,
+            endpoint=endpoint,
+            retstep=retstep,
+            dtype=dtype,
+            axis=axis,
+            device=device,
+        )
+
+else:
+
+    @implements(np.linspace)
+    def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis=0):
+        return _linspace(
+            start,
+            stop,
+            num=50,
+            endpoint=endpoint,
+            retstep=retstep,
+            dtype=dtype,
+            axis=axis,
+        )
 
 
 @implements(np.logspace)
@@ -736,9 +770,8 @@ def nanquantile(a, *args, **kwargs):
 
 @implements(np.linalg.det)
 def linalg_det(a, *args, **kwargs):
-    return (
-        np.linalg.det._implementation(np.asarray(a), *args, **kwargs)
-        * a.units ** (a.shape[0])
+    return np.linalg.det._implementation(np.asarray(a), *args, **kwargs) * a.units ** (
+        a.shape[0]
     )
 
 

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -649,7 +649,7 @@ def _linspace(
         return result * start.units
 
 
-if NUMPY_VERSION >= Version("2.1.0.dev0"):
+if NUMPY_VERSION >= Version("2.0.0.dev0"):
 
     @implements(np.linspace)
     def linspace(
@@ -691,9 +691,9 @@ else:
 
 @implements(np.logspace)
 def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
-    if (startu := getattr(start, "units", NULL_UNIT)) != NULL_UNIT or (
-        stopu := getattr(stop, "units", NULL_UNIT)
-    ) != NULL_UNIT:
+    startu = getattr(start, "units", NULL_UNIT)
+    stopu = getattr(stop, "units", NULL_UNIT)
+    if startu != NULL_UNIT or stopu != NULL_UNIT:
         raise TypeError(
             "The first two arguments to numpy.logspace must be dimensionless, "
             f"got units={startu} (arg1) and units={stopu} (arg2). If output with"

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -691,13 +691,13 @@ else:
 
 @implements(np.logspace)
 def logspace(start, stop, num=50, endpoint=True, base=10, dtype=None, axis=0):
-    if (startu := getattr(start, "units", NULL_UNIT)) != NULL_UNIT:
+    if (startu := getattr(start, "units", NULL_UNIT)) != NULL_UNIT or (
+        stopu := getattr(stop, "units", NULL_UNIT)
+    ) != NULL_UNIT:
         raise TypeError(
-            f"The first argument to numpy.logspace must be dimensionless, got units={startu}"
-        )
-    if (stopu := getattr(stop, "units", NULL_UNIT)) != NULL_UNIT:
-        raise TypeError(
-            f"The second argument to numpy.logspace must be dimensionless, got units={stopu}"
+            "The first two arguments to numpy.logspace must be dimensionless, "
+            f"got units={startu} (arg1) and units={stopu} (arg2). If output with"
+            " units is desired, apply the units to the `base` kwarg."
         )
     result = np.logspace._implementation(
         np.asarray(start),

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -626,16 +626,16 @@ def _linspace(
     device=None,
 ):
     _validate_units_consistency((start, stop))
-    result = np.linspace._implementation(
-        np.asarray(start),
-        np.asarray(stop),
+    kwargs = dict(
         num=num,
         endpoint=endpoint,
         retstep=retstep,
         dtype=dtype,
         axis=axis,
-        device=device,
     )
+    if NUMPY_VERSION >= Version("2.1.0.dev0"):
+        kwargs["device"] = device
+    result = np.linspace._implementation(np.asarray(start), np.asarray(stop), **kwargs)
     if retstep:
         return result[0] * start.units, result[1] * start.units
     else:

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -770,8 +770,9 @@ def nanquantile(a, *args, **kwargs):
 
 @implements(np.linalg.det)
 def linalg_det(a, *args, **kwargs):
-    return np.linalg.det._implementation(np.asarray(a), *args, **kwargs) * a.units ** (
-        a.shape[0]
+    return (
+        np.linalg.det._implementation(np.asarray(a), *args, **kwargs)
+        * a.units ** (a.shape[0])
     )
 
 

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -286,9 +286,16 @@ def _histogramdd(
     # don't getattr(..., "units", NULL_UNIT) because e.g. we don't want
     # a unyt_array if weights are not a unyt_array and not density
     if density:
+        divider_units = 1 * NULL_UNIT
         for s in sample:
-            counts /= getattr(s, "units", 1)
-    counts *= getattr(weights, "units", 1)
+            if not hasattr(s, "units"):
+                continue
+            divider_units *= s.units
+        if divider_units != NULL_UNIT:
+            counts /= divider_units
+
+    if weights is not None and hasattr(weights, "units"):
+        counts *= weights.units
     return counts, tuple(_bin * getattr(s, "units", 1) for _bin, s in zip(bins, sample))
 
 

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -626,13 +626,13 @@ def _linspace(
     device=None,
 ):
     _validate_units_consistency((start, stop))
-    kwargs = dict(
-        num=num,
-        endpoint=endpoint,
-        retstep=retstep,
-        dtype=dtype,
-        axis=axis,
-    )
+    kwargs = {
+        "num": num,
+        "endpoint": endpoint,
+        "retstep": retstep,
+        "dtype": dtype,
+        "axis": axis,
+    }
     if NUMPY_VERSION >= Version("2.1.0.dev0"):
         kwargs["device"] = device
     result = np.linspace._implementation(np.asarray(start), np.asarray(stop), **kwargs)
@@ -729,9 +729,8 @@ def nanquantile(a, *args, **kwargs):
 
 @implements(np.linalg.det)
 def linalg_det(a, *args, **kwargs):
-    return (
-        np.linalg.det._implementation(np.asarray(a), *args, **kwargs)
-        * a.units ** (a.shape[0])
+    return np.linalg.det._implementation(np.asarray(a), *args, **kwargs) * a.units ** (
+        a.shape[0]
     )
 
 

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -729,8 +729,9 @@ def nanquantile(a, *args, **kwargs):
 
 @implements(np.linalg.det)
 def linalg_det(a, *args, **kwargs):
-    return np.linalg.det._implementation(np.asarray(a), *args, **kwargs) * a.units ** (
-        a.shape[0]
+    return (
+        np.linalg.det._implementation(np.asarray(a), *args, **kwargs)
+        * a.units ** (a.shape[0])
     )
 
 

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -1248,7 +1248,10 @@ def test_linspace_with_retstep():
 
 
 def test_logspace_with_units_raises():
-    with pytest.raises(TypeError, match="The first argument"):
+    with pytest.raises(
+        TypeError,
+        match="The first argument to numpy.logspace must be dimensionless, got units=",
+    ):
         np.logspace(1 * cm, 2 * cm)
 
 

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -9,7 +9,7 @@ import pytest
 from numpy.testing import assert_allclose
 from packaging.version import Version
 
-from unyt import A, K, cm, degC, delta_degC, g, km, rad, s, dimensionless
+from unyt import A, K, cm, degC, delta_degC, dimensionless, g, km, rad, s
 from unyt._array_functions import (
     _HANDLED_FUNCTIONS as HANDLED_FUNCTIONS,
     _UNSUPPORTED_FUNCTIONS as UNSUPPORTED_FUNCTIONS,

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -9,7 +9,7 @@ import pytest
 from numpy.testing import assert_allclose
 from packaging.version import Version
 
-from unyt import A, K, cm, degC, delta_degC, dimensionless, g, km, rad, s
+from unyt import A, K, cm, degC, delta_degC, dimensionless, g, km, rad, s, Msun
 from unyt._array_functions import (
     _HANDLED_FUNCTIONS as HANDLED_FUNCTIONS,
     _UNSUPPORTED_FUNCTIONS as UNSUPPORTED_FUNCTIONS,

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -1233,8 +1233,8 @@ def test_isclose_error():
         np.isclose(x, y)
 
 
-def test_linspace(retstep):
-    res = np.linspace(1 * cm, 11 * cm, 10, retstep=retstep)
+def test_linspace():
+    res = np.linspace(1 * cm, 11 * cm, 10)
     assert type(res) is unyt_array
     assert res.units == cm
 

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -831,6 +831,12 @@ class TestHistograms:
         assert not hasattr(ywbins2, "units")
         assert not hasattr(zwbins2, "units")
 
+    @pytest.mark.parametrize("weights", [None, [0, 1, 2], [0, 1, 2] * cm])
+    def test_histogramdd_recursion(self, weights):
+        # regression test for https://github.com/yt-project/unyt/issues/540
+        sample = [unyt_array(np.arange(3), Msun)]
+        np.histogramdd(sample, density=True, weights=weights)
+
     def test_histogram_bin_edges(self):
         rng = np.random.default_rng()
         arr = rng.normal(size=1000) * cm

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -1250,7 +1250,7 @@ def test_linspace_with_retstep():
 def test_logspace_with_units_raises():
     with pytest.raises(
         TypeError,
-        match="The first argument to numpy.logspace must be dimensionless, got units=",
+        match="The first two arguments to numpy.logspace must be dimensionless",
     ):
         np.logspace(1 * cm, 2 * cm)
 

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -1233,16 +1233,18 @@ def test_isclose_error():
         np.isclose(x, y)
 
 
-@pytest.mark.parametrize("retstep", (True, False))
 def test_linspace(retstep):
     res = np.linspace(1 * cm, 11 * cm, 10, retstep=retstep)
-    if retstep:
-        res, step = res
     assert type(res) is unyt_array
     assert res.units == cm
-    if retstep:
-        assert type(step) is unyt_quantity
-        assert step.units == cm
+
+
+def test_linspace_with_retstep():
+    res, step = np.linspace(1 * cm, 11 * cm, 10, retstep=True)
+    assert type(res) is unyt_array
+    assert res.units == cm
+    assert type(step) is unyt_quantity
+    assert step.units == cm
 
 
 def test_logspace_with_units_raises():

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -9,7 +9,7 @@ import pytest
 from numpy.testing import assert_allclose
 from packaging.version import Version
 
-from unyt import A, K, cm, degC, delta_degC, g, km, rad, s
+from unyt import A, K, cm, degC, delta_degC, g, km, rad, s, dimensionless
 from unyt._array_functions import (
     _HANDLED_FUNCTIONS as HANDLED_FUNCTIONS,
     _UNSUPPORTED_FUNCTIONS as UNSUPPORTED_FUNCTIONS,
@@ -1227,16 +1227,37 @@ def test_isclose_error():
         np.isclose(x, y)
 
 
-@pytest.mark.parametrize(
-    "func",
-    [
-        np.linspace,
-        np.logspace,
-        np.geomspace,
-    ],
-)
-def test_xspace(func):
-    res = func(1 * cm, 11 * cm, 10)
+@pytest.mark.parametrize("retstep", (True, False))
+def test_linspace(retstep):
+    res = np.linspace(1 * cm, 11 * cm, 10, retstep=retstep)
+    if retstep:
+        res, step = res
+    assert type(res) is unyt_array
+    assert res.units == cm
+    if retstep:
+        assert type(step) is unyt_quantity
+        assert step.units == cm
+
+
+def test_logspace_with_units_raises():
+    with pytest.raises(TypeError, match="The first argument"):
+        np.logspace(1 * cm, 2 * cm)
+
+
+def test_logspace_with_base():
+    res = np.logspace(1, 2, base=10 * cm)
+    assert type(res) is unyt_array
+    assert res.units == cm
+
+
+def test_logspace_with_dimless_input():
+    res = np.logspace(1 * dimensionless, 2 * dimensionless)
+    assert type(res) is unyt_array
+    assert res.units == dimensionless
+
+
+def test_geomspace():
+    res = np.geomspace(1 * cm, 11 * cm, 10)
     assert type(res) is unyt_array
     assert res.units == cm
 


### PR DESCRIPTION
The implementations of `linspace` and `logspace` are improved so that `retstep` can be used with `linspace` and `logspace` rejects inputs for `start` and `stop` with non-dimensionless units, and also correctly handles the `base` keyword argument with units.

Tests are updated to reflect changes.

Closes #542
Closes #543