### PR TITLE
BUG: `apply_over_axes` no longer assumes user-supplied function preserves units

### DIFF
--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -850,7 +850,7 @@ def savetxt(fname, X, *args, **kwargs):
 
 @implements(np.apply_over_axes)
 def apply_over_axes(func, a, axes):
-    res = func(np.asarray(a), axes[0]) * a.units
+    res = func(a, axes[0])
     if len(axes) > 1:
         # this function is recursive by nature,
         # here we intentionally do not call the base _implementation

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -1657,9 +1657,9 @@ def test_apply_along_axis():
 @pytest.mark.parametrize(
     "axes_expectunits",
     (
-        ((0, 1), cm ** 4),
-        ((0, ), cm ** 2),
-    )
+        ((0, 1), cm**4),
+        ((0,), cm**2),
+    ),
 )
 def test_apply_over_axes(axes_expectunits):
     axes, expectunits = axes_expectunits

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -1654,15 +1654,23 @@ def test_apply_along_axis():
     assert ret.units == cm**2
 
 
-def test_apply_over_axes():
+@pytest.mark.parametrize(
+    "axes_expectunits",
+    (
+        ((0, 1), cm ** 4),
+        ((0, ), cm ** 2),
+    )
+)
+def test_apply_over_axes(axes_expectunits):
+    axes, expectunits = axes_expectunits
     # the user-supplied function must be trusted to treat units
     # sensibly (mainly that it doesn't give a mix of units across
     # the resulting array), but we can check that units are
     # propagated correctly for well-behaved functions.
     a = np.eye(3) * cm
-    ret = np.apply_over_axes(lambda x, axis: x ** 2, a, (0, 1))
-    assert type(ret) is unyt_array
-    assert ret.units == cm**4
+    ret = np.apply_over_axes(lambda x, axis: x[axis] ** 2, a, axes)
+    assert isinstance(ret, unyt_array)  # could be subclass unyt_quantity
+    assert ret.units == expectunits
 
 
 def test_array_equal():

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -1655,10 +1655,14 @@ def test_apply_along_axis():
 
 
 def test_apply_over_axes():
+    # the user-supplied function must be trusted to treat units
+    # sensibly (mainly that it doesn't give a mix of units across
+    # the resulting array), but we can check that units are
+    # propagated correctly for well-behaved functions.
     a = np.eye(3) * cm
-    ret = np.apply_over_axes(lambda x, axis: x * cm, a, (0, 1))
+    ret = np.apply_over_axes(lambda x, axis: x ** 2, a, (0, 1))
     assert type(ret) is unyt_array
-    assert ret.units == cm**3
+    assert ret.units == cm**4
 
 
 def test_array_equal():

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -1654,15 +1654,8 @@ def test_apply_along_axis():
     assert ret.units == cm**2
 
 
-@pytest.mark.parametrize(
-    "axes_expectunits",
-    (
-        ((0, 1), cm**4),
-        ((0,), cm**2),
-    ),
-)
-def test_apply_over_axes(axes_expectunits):
-    axes, expectunits = axes_expectunits
+@pytest.mark.parametrize("axes, expected_units", [((0, 1), cm**4), ((0,), cm**2)])
+def test_apply_over_axes(axes, expected_units):
     # the user-supplied function must be trusted to treat units
     # sensibly (mainly that it doesn't give a mix of units across
     # the resulting array), but we can check that units are
@@ -1670,7 +1663,7 @@ def test_apply_over_axes(axes_expectunits):
     a = np.eye(3) * cm
     ret = np.apply_over_axes(lambda x, axis: x[axis] ** 2, a, axes)
     assert isinstance(ret, unyt_array)  # could be subclass unyt_quantity
-    assert ret.units == expectunits
+    assert ret.units == expected_units
 
 
 def test_array_equal():

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -1662,7 +1662,7 @@ def test_apply_over_axes(axes, expected_units):
     # propagated correctly for well-behaved functions.
     a = np.eye(3) * cm
     ret = np.apply_over_axes(lambda x, axis: x[axis] ** 2, a, axes)
-    assert isinstance(ret, unyt_array)  # could be subclass unyt_quantity
+    assert isinstance(ret, unyt_array)  # could be unyt_quantity
     assert ret.units == expected_units
 
 


### PR DESCRIPTION
Previously the numpy function `apply_over_axes` assumed that the first argument, a user-supplied function, returned values with the same units as the input, which could give incorrect output (e.g. for a function `lambda x, axis: x ** 2`). It's beyond the scope and ability of `unyt` to strictly enforce consistency here, but the updated function now allows units to propagate naturally through the supplied function.

Closes #545 