### PR TITLE
BUG: allow subclassing in `unyt_array.__array_func__`

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1997,7 +1997,7 @@ class unyt_array(np.ndarray):
         elif out_arr.size == 1:
             out_arr = unyt_array(np.asarray(out_arr), unit)
         else:
-            if ret_class is unyt_quantity:
+            if issubclass(ret_class, unyt_quantity):
                 # This happens if you do ndarray * unyt_quantity.
                 # Explicitly casting to unyt_array avoids creating a
                 # unyt_quantity with size > 1


### PR DESCRIPTION
This is a one-line change to enable subclasses of `unyt_quantity` to work properly, otherwise the subclass will not recognize itself as being a `unyt_quantity` and the logic breaks.