### PR TITLE
BUG: fix a regression where `np.linspace`'s num argument would be ignored for `unyt_array`s

### DIFF
--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -666,7 +666,7 @@ if NUMPY_VERSION >= Version("2.0.0.dev0"):
         return _linspace(
             start,
             stop,
-            num=50,
+            num=num,
             endpoint=endpoint,
             retstep=retstep,
             dtype=dtype,
@@ -681,7 +681,7 @@ else:
         return _linspace(
             start,
             stop,
-            num=50,
+            num=num,
             endpoint=endpoint,
             retstep=retstep,
             dtype=dtype,


### PR DESCRIPTION
This fixes a regression I overlooked when reviewing #544 but poped up in yt's test suite https://github.com/yt-project/yt/issues/5091

for posterity: this regression never landed in a release.