### PR TITLE
RFC: handle `np.vecdot` as a ufunc rather than an arrayfunc

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -428,6 +428,8 @@ binary_operators = (
     divmod_,
     heaviside,
 )
+if NUMPY_VERSION >= Version("2.0.0.dev0"):
+    binary_operators += (vecdot,)
 
 trigonometric_operators = (sin, cos, tan)
 

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -132,6 +132,10 @@ from unyt.unit_symbols import delta_degC, delta_degF
 
 from ._deprecation import warn_deprecated
 
+NUMPY_VERSION = Version(version("numpy"))
+if NUMPY_VERSION >= Version("2.0.0.dev0"):
+    from numpy import vecdot
+
 NULL_UNIT = Unit()
 POWER_MAPPING = {multiply: lambda x: x, divide: lambda x: 2 - x}
 DISALLOWED_DTYPES = (
@@ -576,6 +580,8 @@ class unyt_array(np.ndarray):
         matmul: _multiply_units,
         clip: _passthrough_unit,
     }
+    if NUMPY_VERSION >= Version("2.0.0.dev0"):
+        _ufunc_registry[vecdot] = _multiply_units
 
     __array_priority__ = 2.0
 

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -589,7 +589,7 @@ def test_matrix_transpose(namespace):
 @pytest.mark.skipif(
     NUMPY_VERSION < Version("2.0.0dev0"), reason="vecdot is new in numpy 2.0"
 )
-def test_vecdot(namespace):
+def test_vecdot():
     a = np.arange(0, 9)
     assert_array_equal_units(np.linalg.vecdot(a, a), np.vdot(a, a))
 

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -587,9 +587,9 @@ def test_matrix_transpose(namespace):
 
 
 @pytest.mark.skipif(
-    NUMPY_VERSION < Version("2.0.0dev0"), reason="vecdot is new in numpy 2.0"
+    NUMPY_VERSION < Version("2.0.0dev0"), reason="linalg.vecdot is new in numpy 2.0"
 )
-def test_vecdot():
+def test_linalg_vecdot():
     a = np.arange(0, 9)
     assert_array_equal_units(np.linalg.vecdot(a, a), np.vdot(a, a))
 

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -589,14 +589,9 @@ def test_matrix_transpose(namespace):
 @pytest.mark.skipif(
     NUMPY_VERSION < Version("2.0.0dev0"), reason="vecdot is new in numpy 2.0"
 )
-@pytest.mark.parametrize("namespace", [None, "linalg"])
 def test_vecdot(namespace):
-    if namespace is None:
-        func = np.vecdot
-    else:
-        func = getattr(np, namespace).vecdot
     a = np.arange(0, 9)
-    assert_array_equal_units(func(a, a), np.vdot(a, a))
+    assert_array_equal_units(np.linalg.vecdot(a, a), np.vdot(a, a))
 
 
 @pytest.mark.skipif(

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -181,7 +181,6 @@ if NUMPY_VERSION >= Version("2.0.0dev0"):
         np.unique_counts,
         np.unique_inverse,
         np.unique_values,
-        np.vecdot,
     }
 
 if NUMPY_VERSION >= Version("2.1.0dev0"):


### PR DESCRIPTION
In the tests of array functions, one of the tested functions `np.vecdot` is actually a ufunc. I'm relying on the set of `NOOP_FUNCTIONS` in an in-development addition to the https://github.com/SWIFTSIM/swiftsimio test suite to check that our code at least supports all numpy functions supported by unyt, and having a (single) ufunc in the list breaks things. I'm therefore proposing to remove it from the list here. I've also removed the test of the function, perhaps it should be migrated to `test_unyt_array.py`, but I can't spot an obvious place to put it.

Note that `np.linalg.vecdot` *is* an array function, not a ufunc.