### PR TITLE
Don't use multiplication to attach units to result.

### DIFF
--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -771,8 +771,9 @@ def nanquantile(a, *args, **kwargs):
 
 @implements(np.linalg.det)
 def linalg_det(a, *args, **kwargs):
-    return np.linalg.det._implementation(np.asarray(a), *args, **kwargs) * a.units ** (
-        a.shape[0]
+    return (
+        np.linalg.det._implementation(np.asarray(a), *args, **kwargs)
+        * a.units ** (a.shape[0])
     )
 
 

--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -484,7 +484,8 @@ def around(a, decimals=0, out=None):
 @implements(np.block)
 def block(arrays):
     ret_units = _validate_units_consistency(arrays)
-    return np.block._implementation(arrays) * ret_units
+    res = np.block._implementation(arrays)
+    return unyt_array(res, ret_units, bypass_validation=True)
 
 
 @implements(np.fft.fft)
@@ -770,9 +771,8 @@ def nanquantile(a, *args, **kwargs):
 
 @implements(np.linalg.det)
 def linalg_det(a, *args, **kwargs):
-    return (
-        np.linalg.det._implementation(np.asarray(a), *args, **kwargs)
-        * a.units ** (a.shape[0])
+    return np.linalg.det._implementation(np.asarray(a), *args, **kwargs) * a.units ** (
+        a.shape[0]
     )
 
 


### PR DESCRIPTION
I realised that in [swiftsimio](https://github.com/SWIFTSIM/swiftsimio) we wanted to support `__mul__` and similar methods on our array class. This revealed that the implementation of `np.block` in unyt attaches units to the result by multiplying them on, which results in a partially initialised object calling `__mul__` on our side when we wrap `np.block`. This PR changes the wrapper for `np.block` to attach units using the `unyt_array` constructor, in line with other similar helper functions.