### PR TITLE
Delegate unit multiplication when able

### DIFF
--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -376,6 +376,12 @@ class Unit:
     def __mul__(self, u):
         """Multiply Unit with u (Unit object)."""
         if not getattr(u, "is_Unit", False):
+            try:
+                external_result = u.__rmul__(self)
+            except (TypeError, AttributeError):
+                pass
+            else:
+                return external_result
             data = np.array(u, subok=True)
             unit = getattr(u, "units", None)
             if unit is not None:


### PR DESCRIPTION
I have a subclass of `unyt_array` called `cosmo_array`. If I do `cosmo_array(...) * u.cm` the units multiply on as expected and I get back a result with `cosmo_array` type (and my subclass can do whatever it needs to in its `__mul__` method).

However, if I do `u.cm * cosmo_array(...)` then the units still multiply on as expected, but the result is silently demoted to a `unyt_array`. There is _nothing_ that can be done about this downstream because python checks the type of the left argument and first calls its `__mul__` method, only if that fails is control passed to the right argument's `__rmul__` method to see if the right argument knows how to handle the operation.

This PR proposes to let the right argument try to handle the unit multiplication if it knows how to by calling its `__rmul__` method. This resolved the issue with `u.cm * cosmo_array(...)` since my subclass implements a suitable `__rmul__`. It also does not seem to break any existing functionality.

This PR is a draft: I wanted to float the idea first before fleshing it out. The same treatment needs to be applied to `__truediv__`, for instance, and some test coverage is probably wanted.

Maybe breaking the conventional priority of `__mul__` over `__rmul__` in python is a horrific Thing That Should Not Be Done, I'm not sure, but would like to discuss.