### PR TITLE
DEP: declare test dependencies as PEP 735 dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,30 @@ Homepage = "https://github.com/yt-project/unyt"
 Documentation = "https://unyt.readthedocs.io/en/stable/index.html"
 Changelog = "https://unyt.readthedocs.io/en/stable/history.html"
 
+[dependency-groups]
+test = [
+    "pytest-doctestplus>=1.2.1",
+    "pytest>=7.2.1",
+]
+covcheck = [
+    "coverage[toml]>=5.0.0",
+]
+doc = [
+    "docutils>=0.21.2",
+    "sphinx>=7.4.7",
+]
+integration = [
+    "astropy>=4.0.4",
+    "astropy>=5.0.0 ; platform_machine=='arm64' and platform_system=='Darwin'",
+    "dask[array,diagnostics]>=2021.4.1",
+    "dask[array,diagnostics]>=2021.5.1 ; platform_machine=='arm64' and platform_system=='Darwin'",
+    "h5py>=3.0.0",
+    "h5py>=3.7.0 ; platform_machine=='arm64' and platform_system=='Darwin'",
+    "matplotlib>=3.3.3,!=3.5.0",
+    "matplotlib>=3.5.1 ; platform_machine=='arm64' and platform_system=='Darwin'",
+    "pint>=0.9",
+]
+
 [tool.setuptools]
 include-package-data = true
 zip-safe = false

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+min_version = 4.22.0 # for pep 735 dependency groups
 envlist = py310-docs,begin,py310-dependencies,py310-versions,py{310,311,312,313},py310-unyt-module-test-function,end
 isolated_build = True
 
@@ -10,32 +11,28 @@ python =
     3.13: py313
 
 [testenv]
+depends = begin
 package = wheel
 wheel_build_env = .pkg
 setenv =
     PYTHONPATH = {toxinidir}
     MPLBACKEND = agg
 recreate = true
-depends = begin
-deps =
-    pytest
-    h5py
-    pint
-    astropy!=6.1.1
-    coverage[toml]>=5.0
-    pytest-cov
-    pytest-doctestplus
-    matplotlib
-    docutils
-    dask[array,diagnostics]
+dependency_groups =
+    test
+    covcheck
+    doc
+    integration
 commands =
-    pytest --cov=unyt --cov-append --doctest-modules --doctest-plus --doctest-rst --basetemp={envtmpdir}
+    coverage run --append -m pytest --doctest-modules --doctest-plus --doctest-rst --basetemp={envtmpdir}
     coverage report --omit='.tox/*'
 
 [testenv:py310-versions]
+# TODO: drop `deps` in favor of `dependency_groups`
+# via tox-uv with uv_resolution=lowest-direct
 deps =
-    docutils
-    pytest
+    docutils==0.21.2
+    pytest==7.2.1
     sympy==1.9.0
     numpy==1.21.3
     packaging==20.9
@@ -43,59 +40,58 @@ deps =
     pint==0.9
     astropy==5.0.0
     matplotlib==3.5.1
-    coverage[toml]
-    pytest-cov
-    pytest-doctestplus
+    coverage[toml]==5.0.0
+    pytest-doctestplus==1.2.1
     dask[array,diagnostics]==2022.01.0
 commands =
+    {list_dependencies_command}
     # don't do doctests on old numpy versions
-    pytest --cov=unyt --cov-append --basetemp={envtmpdir}
+    coverage run --append -m pytest --basetemp={envtmpdir}
     coverage report --omit='.tox/*'
 
 [testenv:py310-dependencies]
-deps =
-    docutils
-    pytest
-    coverage[toml]
-    pytest-cov
-    pytest-doctestplus
 depends = begin
+dependency_groups =
+    doc
+    test
+    covcheck
 commands =
     # don't do doctests in rst files due to lack of way to specify optional
     # test dependencies there
-    pytest --cov=unyt --cov-append --doctest-modules --doctest-plus --basetemp={envtmpdir}
+    coverage run --append -m pytest --doctest-modules --doctest-plus --basetemp={envtmpdir}
     coverage report --omit='.tox/*'
 
 [testenv:py310-docs]
 allowlist_externals = make
 changedir = docs
-deps =
-    pytest
-    sphinx
-    matplotlib
-    dask[array,diagnostics]
+dependency_groups =
+    test
+    doc
+    integration
 commands =
     make clean
     python -m sphinx -M html "." "_build" -W
 
 [testenv:py310-unyt-module-test-function]
 depends = py310
+dependency_groups =
+    test
 commands =
     python -c 'import unyt; unyt.test()'
 
 [testenv:begin]
-commands =
-    coverage erase
 depends =
 skip_install = true
-deps =
-    coverage[toml]
+dependency_groups =
+    covcheck
+commands =
+    coverage erase
 
 [testenv:end]
+depends = py{310,311,312,313}
+skip_install = true
+dependency_groups =
+    covcheck
 commands =
     coverage report --omit='.tox/*'
     coverage html --omit='.tox/*'
-skip_install = true
-depends = py{39,310,311,312}
-deps =
-    coverage[toml]


### PR DESCRIPTION
This is the fundamental piece from #532. I've stripped out the (partially broken) changes to CI, but this is already useful on it's own: it allows running the test suite with `uv run --group test pytest unyt` instead of a `tox` command.