### PR TITLE
MNT: adjust license spec to PEP 639

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 include AUTHORS.rst
 include CONTRIBUTING.rst
 include HISTORY.rst
-include LICENSE
 include README.rst
 
 recursive-exclude * __pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools>=61.2",
+  "setuptools>=77.0.0",
   "setuptools_scm[toml]>=7.0.1",
 ]
 
@@ -12,10 +12,12 @@ description = "A package for handling numpy arrays with units"
 authors = [
     { name = "The yt project", email = "yt-dev@python.org" },
 ]
+license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
+    "Intended Audience :: Science/Research",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -36,9 +38,6 @@ dynamic = [
 [project.readme]
 file = "README.rst"
 content-type = "text/x-rst"
-
-[project.license]
-text = "BSD-3-Clause"
 
 [project.urls]
 Homepage = "https://github.com/yt-project/unyt"
@@ -72,9 +71,6 @@ integration = [
 [tool.setuptools]
 include-package-data = true
 zip-safe = false
-license-files = [
-    "LICENSE",
-]
 
 [tool.setuptools.packages.find]
 include = [


### PR DESCRIPTION
`project.license` is deprecated as a TOML table since `setuptools` `77.0.0`:
https://setuptools.pypa.io/en/latest/history.html#id73
I adjusted for this change using the now prefered standard, [PEP 639](https://peps.python.org/pep-0639/#deprecate-license-key-table-subkeys), which also mentions the `License :: OSI Approved :: BSD License` classifier being ambiguous, and as such, leads to an error in `setuptools` if present, because it would override PEP 639 definitions, so I removed it.
Setuptools also auto-includes files listed in `project.license-files`, so we don't need to explicitly ask for it in `MANIFEST.in`

While I was at it, I noticed we were missing an obvious `Intended Audience` trove classifier, so I added it.