### PR TITLE
TST: add missing dependency metadata to run with 'mindeps' tox env with any supported Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ keywords = [
 requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.21.3, <3.0",
+    "numpy>=1.23.2 ; python_version>='3.11'",
+    "numpy>=1.26.0 ; python_version>='3.12'",
+    "numpy>=2.1.0 ; python_version>='3.13'",
     "sympy>=1.9.0",
     "packaging>=20.9",
 ]
@@ -48,7 +51,7 @@ Changelog = "https://unyt.readthedocs.io/en/stable/history.html"
 [dependency-groups]
 test = [
     "pytest-doctestplus>=1.2.1",
-    "pytest>=7.2.1",
+    "pytest>=8.0.0",
 ]
 covcheck = [
     "coverage[toml]>=5.0.0",
@@ -60,12 +63,22 @@ doc = [
 integration = [
     "astropy>=4.0.4",
     "astropy>=5.0.0 ; platform_machine=='arm64' and platform_system=='Darwin'",
+    "astropy>=5.0.5 ; python_version>='3.11'",
+    "astropy>=5.3.4 ; python_version>='3.12'",
+    "astropy>=6.1.3 ; python_version>='3.13'",
     "dask[array,diagnostics]>=2021.4.1",
     "dask[array,diagnostics]>=2021.5.1 ; platform_machine=='arm64' and platform_system=='Darwin'",
+    "dask[array,diagnostics]>=2022.1.0 ; python_version>='3.13'",
     "h5py>=3.0.0",
     "h5py>=3.7.0 ; platform_machine=='arm64' and platform_system=='Darwin'",
+    "h5py>=3.8.0 ; python_version>='3.11'",
+    "h5py>=3.10.0 ; python_version>='3.12'",
+    "h5py>=3.12.0 ; python_version>='3.13'",
     "matplotlib>=3.3.3,!=3.5.0",
     "matplotlib>=3.5.1 ; platform_machine=='arm64' and platform_system=='Darwin'",
+    "matplotlib>=3.6.0 ; python_version>='3.11'",
+    "matplotlib>=3.7.3 ; python_version>='3.12'",
+    "matplotlib>=3.9.2 ; python_version>='3.13'",
     "pint>=0.9",
 ]
 
@@ -89,7 +102,6 @@ namespaces = false
 unyt = [
     "tests/data/old_json_registry.txt",
 ]
-
 
 [tool.black]
 exclude = '''
@@ -118,6 +130,7 @@ exclude = [
     "*/_version.py",
     "*/__init__.py",
 ]
+
 [tool.ruff.lint]
 ignore = [
     "E501",
@@ -163,3 +176,6 @@ omit = [
     "unyt/_on_demand_imports.py",
     "unyt/tests/test_linters.py",
 ]
+
+[tool.uv]
+no-build-package = ["astropy", "h5py", "matplotlib", "numpy", "pandas"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,15 @@
 [tox]
 min_version = 4.22.0 # for pep 735 dependency groups
-envlist = py310-docs,begin,py310-dependencies,py310-versions,py{310,311,312,313},py310-unyt-module-test-function,end
+envlist = py310-docs,begin,py310-no_optional_deps,py310-mindeps,py{310,311,312,313},py310-unyt-module-test-function,end
 isolated_build = True
+
+uv_resolution =
+    mindeps: 'lowest-direct'
+    !mindeps: 'highest'
 
 [gh-actions]
 python =
-    3.10: py310, py310-docs, py310-dependencies, py310-versions, py310-unyt-module-test-function
+    3.10: py310, py310-docs, py310-no_optional_deps, py310-mindeps, py310-unyt-module-test-function
     3.11: py311
     3.12: py312
     3.13: py313
@@ -27,29 +31,14 @@ commands =
     coverage run --append -m pytest --doctest-modules --doctest-plus --doctest-rst --basetemp={envtmpdir}
     coverage report --omit='.tox/*'
 
-[testenv:py310-versions]
-# TODO: drop `deps` in favor of `dependency_groups`
-# via tox-uv with uv_resolution=lowest-direct
-deps =
-    docutils==0.21.2
-    pytest==7.2.1
-    sympy==1.9.0
-    numpy==1.21.3
-    packaging==20.9
-    h5py==3.7.0
-    pint==0.9
-    astropy==5.0.0
-    matplotlib==3.5.1
-    coverage[toml]==5.0.0
-    pytest-doctestplus==1.2.1
-    dask[array,diagnostics]==2022.01.0
+[testenv:mindeps]
 commands =
     {list_dependencies_command}
     # don't do doctests on old numpy versions
     coverage run --append -m pytest --basetemp={envtmpdir}
     coverage report --omit='.tox/*'
 
-[testenv:py310-dependencies]
+[testenv:py310-no_optional_deps]
 depends = begin
 dependency_groups =
     doc


### PR DESCRIPTION
Follow up to #574 
this should allow running the test suite with "minimal dependencies" regardless of which Python version is running, not just 3.10, without having to (and most likely, fail to) build packages that ship binary extensions.