### PR TITLE
MNT: remove unused ruff rule config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,6 @@ exclude = [
 ignore = [
     "E501",
     "B904",
-    "UP038", # non-pep604-isinstance
     "B905", # zip-without-explicit-strict
 ]
 select = [


### PR DESCRIPTION
This specific rule is deprecated and disabled by default, hence, current versions of ruff warn about ignoring it as a no-op. This avoids the warning.