### PR TITLE
TST: enable reproducible envs for oldestdeps jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [build]
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version:
@@ -85,7 +86,7 @@ jobs:
           # with lowest direct dependencies
           - os: ubuntu-22.04
             python-version: '3.10.0'
-            sync-args: --resolution=lowest-direct --group integration
+            sync-args: --resolution=lowest --group integration
             pytest-args: null
             label: oldestdeps
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,13 +46,13 @@ Changelog = "https://unyt.readthedocs.io/en/stable/history.html"
 
 [dependency-groups]
 test = [
-    "pytest-doctestplus>=1.2.1",
-    "pytest>=7.2.1",
+    "pytest-doctestplus>=1.4.0",
+    "pytest>=8.0.1",
 ]
 covcheck = [
     {include-group = "test"},
     "coverage[toml] ; python_version < '3.11'",
-    "coverage>=5.0.0",
+    "coverage>=7.10.0",
 ]
 doc = [
     {include-group = "integration"},
@@ -78,6 +78,14 @@ no-build-package = [
     "numpy",
     "matplotlib",
     "pandas",
+    "toolz",
+    "pyyaml",
+    "kiwisolver",
+    "pillow",
+    "pyerfa",
+]
+constraint-dependencies = [
+    "mpmath>=1.2.1",
 ]
 
 # ensure that uv resolves envs that are compatible with macOS arm64,


### PR DESCRIPTION
this one job is currently failing because direct dependencies are de-facto pinned but transitive ones aren't. This makes the solution reproducible.