### PR TITLE
Allow other classes to handle multiplication & division with `Unit`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 90
+extend-ignore = E203

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 90
-extend-ignore = E203

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -899,3 +899,53 @@ def test_mixed_registry_operations():
     assert_almost_equal(a * b, b * a)
     assert_almost_equal(b / a, b / a.in_units("km"))
     assert_almost_equal(a / b, a / b.in_units("km"))
+
+
+def test_other_argument_can_handle_multiplication_and_division():
+
+    class MyClass:
+        def __init__(self, x: int):
+            self.x = x
+
+        def __mul__(self, other):
+            return self.x * other
+
+        def __rmul__(self, other):
+            return self.__mul__(other)
+
+        def __truediv__(self, other):
+            return self.x / other
+
+        def __rtruediv__(self, other):
+            return other / self.x
+
+    u = Unit("m")
+    x = 5
+    mc = MyClass(x=x)
+
+    assert_almost_equal(x * u, mc * u)  # handled by MyClass.__mul__
+    assert_almost_equal(x * u, u * mc)  # handled by MyClass.__rmul__
+    assert_almost_equal(x / u, mc / u)  # handled by MyClass.__truediv__
+    assert_almost_equal(u / x, u / mc)  # handled by MyClass.__rtruediv__
+
+
+def test_other_argument_cannot_handle_multiplication_and_division():
+
+    class MyClass:
+        def __init__(self, x: int):
+            self.x = x
+
+    u = Unit("m")
+    x = 5
+    mc = MyClass(x=x)
+    mul_msg = "Tried to multiply a Unit object with"
+    div_msg = "Tried to divide a Unit object by"
+
+    with pytest.raises(InvalidUnitOperation, match=mul_msg):
+        mc * u
+    with pytest.raises(InvalidUnitOperation, match=mul_msg):
+        u * mc
+    with pytest.raises(InvalidUnitOperation, match=mul_msg):
+        mc / u  # handled as multiplication by inverse so expect mul_msg
+    with pytest.raises(InvalidUnitOperation, match=div_msg):
+        u / mc

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -904,14 +904,11 @@ def test_mixed_registry_operations():
 def test_other_argument_can_handle_multiplication_and_division():
 
     class MyClass:
-        def __init__(self, x: int):
+        def __init__(self, x):
             self.x = x
 
         def __mul__(self, other):
             return self.x * other
-
-        def __rmul__(self, other):
-            return self.__mul__(other)
 
         def __truediv__(self, other):
             return self.x / other
@@ -924,7 +921,7 @@ def test_other_argument_can_handle_multiplication_and_division():
     mc = MyClass(x=x)
 
     assert_almost_equal(x * u, mc * u)  # handled by MyClass.__mul__
-    assert_almost_equal(x * u, u * mc)  # handled by MyClass.__rmul__
+    assert_almost_equal(x * u, u * mc)  # handled by MyClass.__mul__
     assert_almost_equal(x / u, mc / u)  # handled by MyClass.__truediv__
     assert_almost_equal(u / x, u / mc)  # handled by MyClass.__rtruediv__
 
@@ -932,8 +929,33 @@ def test_other_argument_can_handle_multiplication_and_division():
 def test_other_argument_cannot_handle_multiplication_and_division():
 
     class MyClass:
-        def __init__(self, x: int):
+        def __init__(self, x):
             self.x = x
+
+    u = Unit("m")
+    x = 5
+    mc = MyClass(x=x)
+    mul_msg = "Tried to multiply a Unit object with"
+    div_msg = "Tried to divide a Unit object by"
+
+    with pytest.raises(InvalidUnitOperation, match=mul_msg):
+        mc * u
+    with pytest.raises(InvalidUnitOperation, match=mul_msg):
+        u * mc
+    with pytest.raises(InvalidUnitOperation, match=mul_msg):
+        mc / u  # handled as multiplication by inverse so expect mul_msg
+    with pytest.raises(InvalidUnitOperation, match=div_msg):
+        u / mc
+
+
+def test_other_argument_explicitly_cannot_handle_multiplication_and_division():
+
+    class MyClass:
+        def __init__(self, x):
+            self.x = x
+
+        def __mul__(self, x):
+            return NotImplemented
 
     u = Unit("m")
     x = 5

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -926,6 +926,30 @@ def test_other_argument_can_handle_multiplication_and_division():
     assert_almost_equal(u / x, u / mc)  # handled by MyClass.__rtruediv__
 
 
+def test_other_argument_typeerror_on_multiplication_or_division():
+
+    class MyClass:
+        def __init__(self):
+            return
+
+        def __mul__(self, other):
+            return other * None  # always raises TypeError
+
+        def __rtruediv__(self, other):
+            return other / None  # always raises TypeError
+
+    u = Unit("m")
+    mc = MyClass()
+    mul_msg = "Tried to multiply a Unit object with"
+    div_msg = "Tried to divide a Unit object by"
+
+    # only test for case when MyClass is right argument, when left it's its own problem
+    with pytest.raises(InvalidUnitOperation, match=mul_msg):
+        u * mc
+    with pytest.raises(InvalidUnitOperation, match=div_msg):
+        u / mc
+
+
 def test_other_argument_cannot_handle_multiplication_and_division():
 
     class MyClass:
@@ -955,6 +979,9 @@ def test_other_argument_explicitly_cannot_handle_multiplication_and_division():
             self.x = x
 
         def __mul__(self, x):
+            return NotImplemented
+
+        def __rtruediv__(self, x):
             return NotImplemented
 
     u = Unit("m")

--- a/unyt/tests/test_units.py
+++ b/unyt/tests/test_units.py
@@ -434,11 +434,11 @@ def test_invalid_operations():
         u1 - 1
     with pytest.raises(InvalidUnitOperation):
         u1 *= u2
-    with pytest.raises(InvalidUnitOperation):
+    with pytest.raises(TypeError):
         u1 * "hello!"
     with pytest.raises(InvalidUnitOperation):
         u1 /= u2
-    with pytest.raises(InvalidUnitOperation):
+    with pytest.raises(TypeError):
         u1 / "hello!"
     with pytest.raises(InvalidUnitOperation):
         Unit("B") * Unit("V")
@@ -910,6 +910,9 @@ def test_other_argument_can_handle_multiplication_and_division():
         def __mul__(self, other):
             return self.x * other
 
+        def __rmul__(self, other):
+            return self.__mul__(other)
+
         def __truediv__(self, other):
             return self.x / other
 
@@ -940,13 +943,13 @@ def test_other_argument_typeerror_on_multiplication_or_division():
 
     u = Unit("m")
     mc = MyClass()
-    mul_msg = "Tried to multiply a Unit object with"
-    div_msg = "Tried to divide a Unit object by"
+    mul_msg = r"unsupported operand type\(s\) for \*"
+    div_msg = r"unsupported operand type\(s\) for \/"
 
     # only test for case when MyClass is right argument, when left it's its own problem
-    with pytest.raises(InvalidUnitOperation, match=mul_msg):
+    with pytest.raises(TypeError, match=mul_msg):
         u * mc
-    with pytest.raises(InvalidUnitOperation, match=div_msg):
+    with pytest.raises(TypeError, match=div_msg):
         u / mc
 
 
@@ -959,16 +962,16 @@ def test_other_argument_cannot_handle_multiplication_and_division():
     u = Unit("m")
     x = 5
     mc = MyClass(x=x)
-    mul_msg = "Tried to multiply a Unit object with"
-    div_msg = "Tried to divide a Unit object by"
+    mul_msg = r"unsupported operand type\(s\) for \*"
+    div_msg = r"unsupported operand type\(s\) for \/"
 
-    with pytest.raises(InvalidUnitOperation, match=mul_msg):
+    with pytest.raises(TypeError, match=mul_msg):
         mc * u
-    with pytest.raises(InvalidUnitOperation, match=mul_msg):
+    with pytest.raises(TypeError, match=mul_msg):
         u * mc
-    with pytest.raises(InvalidUnitOperation, match=mul_msg):
+    with pytest.raises(TypeError, match=mul_msg):
         mc / u  # handled as multiplication by inverse so expect mul_msg
-    with pytest.raises(InvalidUnitOperation, match=div_msg):
+    with pytest.raises(TypeError, match=div_msg):
         u / mc
 
 
@@ -987,14 +990,14 @@ def test_other_argument_explicitly_cannot_handle_multiplication_and_division():
     u = Unit("m")
     x = 5
     mc = MyClass(x=x)
-    mul_msg = "Tried to multiply a Unit object with"
-    div_msg = "Tried to divide a Unit object by"
+    mul_msg = r"unsupported operand type\(s\) for \*"
+    div_msg = r"unsupported operand type\(s\) for \/"
 
-    with pytest.raises(InvalidUnitOperation, match=mul_msg):
+    with pytest.raises(TypeError, match=mul_msg):
         mc * u
-    with pytest.raises(InvalidUnitOperation, match=mul_msg):
+    with pytest.raises(TypeError, match=mul_msg):
         u * mc
-    with pytest.raises(InvalidUnitOperation, match=mul_msg):
+    with pytest.raises(TypeError, match=mul_msg):
         mc / u  # handled as multiplication by inverse so expect mul_msg
-    with pytest.raises(InvalidUnitOperation, match=div_msg):
+    with pytest.raises(TypeError, match=div_msg):
         u / mc

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -402,10 +402,21 @@ class Unit:
             else:
                 units = self
             if data.dtype.kind not in ("f", "u", "i", "c"):
+                # ---------------- OPTION A ---------------
+                if hasattr(u, "__mul__"):
+                    try:
+                        ret = u.__mul__(self)
+                        if ret is not NotImplemented:
+                            return ret
+                    except TypeError:
+                        pass
                 raise InvalidUnitOperation(
                     f"Tried to multiply a Unit object with '{u}' (type {type(u)}). "
                     "This behavior is undefined."
                 )
+                # ---------------- OPTION B ---------------
+                # return NotImplemented
+                # -----------------------------------------
             if data.shape == ():
                 return _import_cache_singleton.uq(data, units, bypass_validation=True)
             return _import_cache_singleton.ua(data, units, bypass_validation=True)
@@ -442,10 +453,21 @@ class Unit:
 
                 return unyt_quantity(1.0, self) / u
             else:
+                # ---------------- OPTION A ---------------
+                if hasattr(u, "__rtruediv__"):
+                    try:
+                        ret = u.__rtruediv__(self)
+                        if ret is not NotImplemented:
+                            return ret
+                    except TypeError:
+                        pass
                 raise InvalidUnitOperation(
                     f"Tried to divide a Unit object by '{u}' (type {type(u)}). "
                     "This behavior is undefined."
                 )
+                # ---------------- OPTION B ---------------
+                # return NotImplemented
+                # -----------------------------------------
         elif self.dimensions is logarithmic and not u.is_dimensionless:
             raise InvalidUnitOperation(f"Tried to divide '{self}' and '{u}'.")
         elif u.dimensions is logarithmic and not self.is_dimensionless:

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -403,19 +403,19 @@ class Unit:
                 units = self
             if data.dtype.kind not in ("f", "u", "i", "c"):
                 # ---------------- OPTION A ---------------
-                if hasattr(u, "__mul__"):
-                    try:
-                        ret = u.__mul__(self)
-                        if ret is not NotImplemented:
-                            return ret
-                    except TypeError:
-                        pass
-                raise InvalidUnitOperation(
-                    f"Tried to multiply a Unit object with '{u}' (type {type(u)}). "
-                    "This behavior is undefined."
-                )
+                # if hasattr(u, "__mul__"):
+                #     try:
+                #         ret = u.__mul__(self)
+                #         if ret is not NotImplemented:
+                #             return ret
+                #     except TypeError:
+                #         pass
+                # raise InvalidUnitOperation(
+                #     f"Tried to multiply a Unit object with '{u}' (type {type(u)}). "
+                #     "This behavior is undefined."
+                # )
                 # ---------------- OPTION B ---------------
-                # return NotImplemented
+                return NotImplemented
                 # -----------------------------------------
             if data.shape == ():
                 return _import_cache_singleton.uq(data, units, bypass_validation=True)
@@ -454,19 +454,19 @@ class Unit:
                 return unyt_quantity(1.0, self) / u
             else:
                 # ---------------- OPTION A ---------------
-                if hasattr(u, "__rtruediv__"):
-                    try:
-                        ret = u.__rtruediv__(self)
-                        if ret is not NotImplemented:
-                            return ret
-                    except TypeError:
-                        pass
-                raise InvalidUnitOperation(
-                    f"Tried to divide a Unit object by '{u}' (type {type(u)}). "
-                    "This behavior is undefined."
-                )
+                # if hasattr(u, "__rtruediv__"):
+                #     try:
+                #         ret = u.__rtruediv__(self)
+                #         if ret is not NotImplemented:
+                #             return ret
+                #     except TypeError:
+                #         pass
+                # raise InvalidUnitOperation(
+                #     f"Tried to divide a Unit object by '{u}' (type {type(u)}). "
+                #     "This behavior is undefined."
+                # )
                 # ---------------- OPTION B ---------------
-                # return NotImplemented
+                return NotImplemented
                 # -----------------------------------------
         elif self.dimensions is logarithmic and not u.is_dimensionless:
             raise InvalidUnitOperation(f"Tried to divide '{self}' and '{u}'.")

--- a/unyt/unit_object.py
+++ b/unyt/unit_object.py
@@ -402,21 +402,7 @@ class Unit:
             else:
                 units = self
             if data.dtype.kind not in ("f", "u", "i", "c"):
-                # ---------------- OPTION A ---------------
-                # if hasattr(u, "__mul__"):
-                #     try:
-                #         ret = u.__mul__(self)
-                #         if ret is not NotImplemented:
-                #             return ret
-                #     except TypeError:
-                #         pass
-                # raise InvalidUnitOperation(
-                #     f"Tried to multiply a Unit object with '{u}' (type {type(u)}). "
-                #     "This behavior is undefined."
-                # )
-                # ---------------- OPTION B ---------------
                 return NotImplemented
-                # -----------------------------------------
             if data.shape == ():
                 return _import_cache_singleton.uq(data, units, bypass_validation=True)
             return _import_cache_singleton.ua(data, units, bypass_validation=True)


### PR DESCRIPTION
Currently if another class wants to implement multiplying with a `Unit`, it can only handle the case where it is the left argument, like:
```python
class MyClass:
    def __init__(self, x):
        self.x = x

    def __mul__(self, other):
        return self.x * other

    def __rmul__(self, other):
        return self.__mul__(other)

MyClass(5) * Unit("m")  # MyClass.__mul__ can handle this
```
When it is the right operand like this:
```python
Unit("m") * MyClass(5)
```
`Unit` raises a `InvalidUnitOperation` before `MyClass.__rmul__` ever has a chance to intervene.

When `Unit` can't resolve the operation itself, I'm proposing to ask the other argument whether it knows what to do and returning the resulting value if it does, otherwise `Unit` will raise as before. This is labelled "Option A" in the proposed changes and keeps the new behaviour as close as possible to the current behaviour at the cost of a more complex implementation.

Alternatively there is "Option B", currently commented out, that would remove the `raise` and simply `return NotImplemented` when `Unit` doesn't know what to do. This is more in line with how a python class is expected to behave but changes how `Unit` behaves.

The included tests have a bare-bones example of how a class might use this functionality.

#641  is related.