### PR TITLE
Allow other (non-sub)classes to handle binary ufuncs with `unyt_array`

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -339,7 +339,7 @@ def _apply_power_mapping(ufunc, in_unit, in_size, in_shape, input_kwarg_dict):
     return mul, unit
 
 
-def _subclass_ufunc_prepare_and_finalize(ufunc_handler):
+def _ufunc_prepare_and_finalize(ufunc_handler):
     """
     This wrapper function is intended to be applied to __array_ufunc__ on
     unyt_array.
@@ -348,6 +348,12 @@ def _subclass_ufunc_prepare_and_finalize(ufunc_handler):
     classmethods: __unyt_ufunc_prepare__ and __unyt_ufunc_finalize__.
     These are called if available to allow subclasses to prepare arguments
     for and modify return values from numpy ufuncs.
+
+    These methods can also be defined on classes that are not subclasses of
+    unyt_array allowing them to participate in resolving applying a binary
+    ufunc to a unyt_array and a second argument of their type. In this case
+    the result is a unyt_array (unless the other class modifies it in its
+    __unyt_ufunc_finalize__ method).
 
     The __unyt_ufunc_prepare__ method should be a classmethod accepting
     (ufunc, method, *inputs, **kwargs), i.e. the same inputs as
@@ -1887,7 +1893,7 @@ class unyt_array(np.ndarray):
     # Start operation methods
     #
 
-    @_subclass_ufunc_prepare_and_finalize
+    @_ufunc_prepare_and_finalize
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         func = getattr(ufunc, method)
         if "out" not in kwargs:

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -381,9 +381,11 @@ def _ufunc_prepare_and_finalize(ufunc_handler):
                 finalize = getattr(ret_class, "__unyt_ufunc_finalize__", None)
 
             except RuntimeError:
+                prepare = None
+                finalize = None
                 for inp in inputs:
-                    prepare = getattr(inp, "__unyt_ufunc_prepare__", None)
-                    finalize = getattr(inp, "__unyt_ufunc_finalize__", None)
+                    prepare = getattr(inp, "__unyt_ufunc_prepare__", prepare)
+                    finalize = getattr(inp, "__unyt_ufunc_finalize__", finalize)
                 if prepare is None and finalize is None:
                     # we're sure none of the arguments want to modify the input
                     # or output, so bypass __unyt_ufunc_prepare__ and

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -371,16 +371,31 @@ def _subclass_ufunc_prepare_and_finalize(ufunc_handler):
                 ret_class = _get_binary_op_return_class(
                     type(inputs[0]), type(inputs[1])
                 )
+                prepare = getattr(ret_class, "__unyt_ufunc_prepare__", None)
+                finalize = getattr(ret_class, "__unyt_ufunc_finalize__", None)
+
             except RuntimeError:
-                # we're sure none of the arguments want to modify the input
-                # or output, so bypass __unyt_ufunc_prepare__ and
-                # __unyt_ufunc_finalize__.
-                return ufunc_handler(self, ufunc, method, *inputs, **kwargs)
+                for inp in inputs:
+                    prepare = getattr(inp, "__unyt_ufunc_prepare__", None)
+                    finalize = getattr(inp, "__unyt_ufunc_finalize__", None)
+                if prepare is None and finalize is None:
+                    # we're sure none of the arguments want to modify the input
+                    # or output, so bypass __unyt_ufunc_prepare__ and
+                    # __unyt_ufunc_finalize__.
+                    return ufunc_handler(self, ufunc, method, *inputs, **kwargs)
+                else:
+                    # one of the arguments has __unyt_ufunc_prepare__ or
+                    # __unyt_ufunc_finalize__ but is not a subclass of unyt_array, we
+                    # trust that they know what they're doing and return a unyt_array
+                    # (or unyt_quantity).
+                    ret_class = type(self)
         else:
             ret_class = type(inputs[0])
-        if hasattr(ret_class, "__unyt_ufunc_prepare__"):
-            prepared_ufunc, prepared_method, prepared_inputs, prepared_kwargs = (
-                ret_class.__unyt_ufunc_prepare__(ufunc, method, *inputs, **kwargs)
+            prepare = getattr(ret_class, "__unyt_ufunc_prepare__", None)
+            finalize = getattr(ret_class, "__unyt_ufunc_finalize__", None)
+        if prepare is not None:
+            prepared_ufunc, prepared_method, prepared_inputs, prepared_kwargs = prepare(
+                ufunc, method, *inputs, **kwargs
             )
         else:
             prepared_ufunc, prepared_method, prepared_inputs, prepared_kwargs = (
@@ -396,10 +411,8 @@ def _subclass_ufunc_prepare_and_finalize(ufunc_handler):
             *prepared_inputs,
             **prepared_kwargs,
         )
-        if hasattr(ret_class, "__unyt_ufunc_finalize__"):
-            return ret_class.__unyt_ufunc_finalize__(
-                result, ufunc, method, *inputs, **kwargs
-            )
+        if finalize is not None:
+            return finalize(result, ufunc, method, *inputs, **kwargs)
         else:
             return result
 

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -3049,3 +3049,58 @@ def test_squeeze_method_with_axis():
     squeeze_axis = (1,)
     arr_squeezed = arr.squeeze(axis=1)
     assert arr_squeezed.ndim == arr.ndim - len(squeeze_axis)
+
+
+def test_other_argument_can_handle_binary_ufunc():
+    class MyClass:
+        def __init__(self, x: int):
+            self.x = x
+
+        @classmethod
+        def __unyt_ufunc_prepare__(cls, ufunc, method, *inputs, **kwargs):
+            return (
+                ufunc,
+                method,
+                tuple(i.x if isinstance(i, MyClass) else i for i in inputs),
+                kwargs,
+            )
+
+        @classmethod
+        def __unyt_ufunc_finalize__(cls, result, ufunc, method, *inputs, **kwargs):
+            return result
+
+    x = 5
+    mc = MyClass(x=x)
+    uq = unyt_quantity(2, "m")
+    ua = unyt_array([2], "m")
+
+    for u in ua, uq:
+        assert_almost_equal(x * u, mc * u)
+        assert_almost_equal(x * u, u * mc)
+        assert_almost_equal(x / u, mc / u)
+        assert_almost_equal(u / x, u / mc)
+
+
+def test_other_argument_cannot_handle_binary_ufunc():
+    class MyClass:
+        def __init__(self, x: int):
+            self.x = x
+
+    x = 5
+    mc = MyClass(x=x)
+    uq = unyt_quantity(2, "m")
+    ua = unyt_array([2], "m")
+
+    msg = (
+        "Received an input or operand that cannot be converted to a "
+        "unyt_array with uniform units"
+    )
+    for u in ua, uq:
+        with pytest.raises(IterableUnitCoercionError, match=msg):
+            mc * u
+        with pytest.raises(IterableUnitCoercionError, match=msg):
+            u * mc
+        with pytest.raises(IterableUnitCoercionError, match=msg):
+            mc / u
+        with pytest.raises(IterableUnitCoercionError, match=msg):
+            u / mc


### PR DESCRIPTION
#572 added the ability for subclasses of `unyt_array` to intervene before and after numpy ufunc calls to "prepare" the arguments and "finalize" the result.

In this PR I propose to extend this ability to classes that are not subclasses, allowing them to implement `__unyt_ufunc_prepare__` and `__unyt_ufunc_finalize__` if they wish. Note that the other class cannot control the result via e.g. `__mul__` and `__rmul__` because control ends up in `unyt_array.__array_ufunc__` and leads to an exception leaving the other class no chance to intervene.

The included tests have a bare-bones example of how a class might use this functionality.

#640 is related.