### PR TITLE
Flag MD5 unit-registry fingerprint as not used for security (fixes #580)

### DIFF
--- a/unyt/tests/test_unit_registry.py
+++ b/unyt/tests/test_unit_registry.py
@@ -176,3 +176,40 @@ def test_old_registry_json():
         val = default_reg[k]
         assert_allclose(loaded_val[0], val[0])
         assert loaded_val[1:] == val[1:]
+
+
+def test_unit_system_id_under_fips(monkeypatch):
+    # On FIPS-enabled systems, hashlib.md5() raises unless it is told the
+    # digest is not used for security. unit_system_id only uses MD5 as a
+    # fingerprint, so it must pass usedforsecurity=False; otherwise simply
+    # importing unyt crashes on such systems (#580).
+    import hashlib
+
+    import unyt.unit_registry as unit_registry
+
+    real_md5 = hashlib.md5
+
+    def fips_md5(*args, **kwargs):
+        # Mimic a FIPS build: refuse to construct an MD5 hasher that is
+        # flagged as being used for security.
+        if kwargs.get("usedforsecurity", True):
+            raise ValueError("[digital envelope routines] unsupported")
+        return real_md5(*args, **kwargs)
+
+    monkeypatch.setattr(unit_registry, "md5", fips_md5)
+
+    reg = UnitRegistry()
+    reg._unit_system_id = None  # force recomputation through the patched md5
+
+    unit_system_id = reg.unit_system_id
+    assert isinstance(unit_system_id, str)
+    # The fingerprint must match the value computed with a regular md5.
+    assert unit_system_id == real_md5(_hash_data_for(reg)).hexdigest()
+
+
+def _hash_data_for(reg):
+    hash_data = bytearray()
+    for k, v in sorted(reg.lut.items()):
+        hash_data.extend(k.encode("utf8"))
+        hash_data.extend(repr(v).encode("utf8"))
+    return bytes(hash_data)

--- a/unyt/unit_registry.py
+++ b/unyt/unit_registry.py
@@ -93,7 +93,11 @@ class UnitRegistry:
             for k, v in sorted(self.lut.items()):
                 hash_data.extend(k.encode("utf8"))
                 hash_data.extend(repr(v).encode("utf8"))
-            m = md5()
+            # This hash is only a fingerprint used to identify a unit
+            # registry, never for security, so flag it accordingly. Without
+            # usedforsecurity=False, importing unyt crashes on FIPS-enabled
+            # systems where MD5 is disabled for security purposes (#580).
+            m = md5(usedforsecurity=False)
             m.update(hash_data)
             self._unit_system_id = str(m.hexdigest())
         return self._unit_system_id


### PR DESCRIPTION
Fixes #580.

## Problem

\`UnitRegistry.unit_system_id\` computes an MD5 digest of the registry's lookup table to produce a unique fingerprint for the unit registry. On FIPS-enabled systems (e.g. the NASA cluster in #580), MD5 is disabled for security, so \`hashlib.md5()\` raises

\`\`\`
ValueError: [digital envelope routines] unsupported
\`\`\`

Because \`unit_system_id\` is reachable during import of the physical-constant registry, this makes \`import unyt\` — and therefore \`import yt\` — fail outright on those systems.

## Fix

The digest here is only a fingerprint used to identify a registry; it is never used for security. Passing \`usedforsecurity=False\` tells the (OpenSSL-backed) hashlib that the MD5 is non-security, which is permitted under FIPS while leaving the resulting hex digest unchanged. The minimum supported Python is 3.10, so the keyword is always available.

## Test

Added \`test_unit_system_id_under_fips\`, which monkeypatches \`md5\` to refuse construction unless \`usedforsecurity=False\` is passed (mirroring a FIPS build) and asserts that \`unit_system_id\` still computes, and that the digest matches the one produced by a regular \`md5\`. The test fails on \`main\` and passes with this change. Full test suite: 779 passed, 25 skipped, 2 xfailed.