### PR TITLE
Make np.digitize unit-aware

### DIFF
--- a/unyt/_array_functions.py
+++ b/unyt/_array_functions.py
@@ -385,6 +385,22 @@ def histogram_bin_edges(a, *args, **kwargs):
     )
 
 
+@implements(np.digitize)
+def digitize(x, bins, right=False):
+    # convert bins to x's units before binning, reusing the same helper as the
+    # histogram functions. This both makes the comparison unit-aware (so e.g.
+    # grams and kilograms give consistent indices) and raises on dimensionally
+    # incompatible bins instead of silently comparing raw values (see #633).
+    if not hasattr(bins, "units"):
+        # let _sanitize_bins operate on an array (it divides bins by a
+        # conversion factor, which a plain list does not support)
+        bins = np.asarray(bins)
+    sanitized_bins = _sanitize_bins(x, bins)
+    return np.digitize._implementation(
+        np.asarray(x), np.asarray(sanitized_bins), right=right
+    )
+
+
 def get_units(objs):
     units = []
     for sub in objs:

--- a/unyt/tests/test_array_functions.py
+++ b/unyt/tests/test_array_functions.py
@@ -148,7 +148,6 @@ NOOP_FUNCTIONS = {
     np.extract,  # works out of the box (tested)
     np.setxor1d,  # we get it for free with previously implemented functions (tested)
     np.lexsort,  # returns pure numbers
-    np.digitize,  # returns pure numbers
     np.tril_indices_from,  # returns pure numbers
     np.triu_indices_from,  # returns pure numbers
     np.imag,  # works out of the box (tested)
@@ -2095,6 +2094,30 @@ def test_searchsorted_mixed_units():
 def test_searchsorted(val):
     res = np.searchsorted([1, 2, 3, 4, 5] * cm, val)
     assert res == 2
+
+
+def test_digitize_converts_bins():
+    # bins in different (but compatible) units must be converted to the data's
+    # units before binning: 1, 2, 3 cm are all far below 1 km, so they all land
+    # in the first bin (see #633)
+    res = np.digitize([1, 2, 3] * cm, [0, 1, 2, 3] * km)
+    assert_array_equal_units(res, np.array([1, 1, 1]))
+
+
+def test_digitize_right():
+    res = np.digitize([1, 2, 3] * cm, [0, 1, 2, 3] * km, right=True)
+    assert_array_equal_units(res, np.array([1, 1, 1]))
+
+
+def test_digitize_dimensionless_plain_bins():
+    # a dimensionless array with plain (unit-less) bins must still work
+    res = np.digitize([1, 2, 3] * dimensionless, [0, 1, 2, 3])
+    assert_array_equal_units(res, np.array([2, 3, 4]))
+
+
+def test_digitize_mixed_units():
+    with pytest.raises(UnitConversionError):
+        np.digitize([1, 2, 3] * g, [0, 1, 2, 3] * s)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #633.

## Problem

`np.digitize` was listed in `NOOP_FUNCTIONS` with the note "returns pure numbers", on the assumption that because it returns plain indices it needs no unit handling. But `digitize` compares the data against the bin edges, so the units of both matter. With no handler the two were compared as raw numbers:

```python
>>> np.digitize([1.1, 2.2, 3.3] * u.g, [0, 1, 2, 3] * u.kg)
array([2, 3, 4])   # wrong — all three values are < 1 kg, so should be array([1, 1, 1])
```

and dimensionally incompatible bins were silently accepted instead of raising:

```python
>>> np.digitize([1.1, 2.2, 3.3] * u.g, [0, 1, 2, 3] * u.s)
array([2, 3, 4])   # should raise
```

## Fix

Add an `@implements(np.digitize)` handler that converts the bins to the data arrays units before delegating to NumPy, reusing the existing `_sanitize_bins` helper that the histogram functions already use. Converting through the unit system means compatible units are reconciled and dimensionally incompatible bins raise `UnitConversionError`:

```python
>>> np.digitize([1.1, 2.2, 3.3] * u.g, [0, 1, 2, 3] * u.kg)
array([1, 1, 1])
>>> np.digitize([1.1, 2.2, 3.3] * u.g, [0, 1, 2, 3] * u.s)
UnitConversionError: ...
```

`np.digitize` is removed from `NOOP_FUNCTIONS` accordingly (the `test_wrapping_completeness` meta-test enforces that handled and not-handled sets stay disjoint).

A unit-less `bins` argument is coerced to an array first so the existing dimensionless-data path keeps working (a plain Python list does not support the division done inside `_sanitize_bins`).

## Tests

Added `test_digitize_converts_bins`, `test_digitize_right`, `test_digitize_dimensionless_plain_bins` and `test_digitize_mixed_units`. Full `test_array_functions.py` (494 passed) and the whole suite (785 passed) are green; ruff lint/format clean.