### PR TITLE
Allow other (non-sub)classes to handle binary ufuncs with `unyt_array`

### DIFF
--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1794,13 +1794,13 @@ class unyt_array(np.ndarray):
     def __eq__(self, other):
         try:
             return super().__eq__(other)
-        except (IterableUnitCoercionError, UnitOperationError):
+        except (IterableUnitCoercionError, UnitOperationError, TypeError):
             return np.zeros(self.shape, dtype="bool")
 
     def __ne__(self, other):
         try:
             return super().__ne__(other)
-        except (IterableUnitCoercionError, UnitOperationError):
+        except (IterableUnitCoercionError, UnitOperationError, TypeError):
             return np.ones(self.shape, dtype="bool")
 
     #

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -339,73 +339,6 @@ def _apply_power_mapping(ufunc, in_unit, in_size, in_shape, input_kwarg_dict):
     return mul, unit
 
 
-def _subclass_ufunc_prepare_and_finalize(ufunc_handler):
-    """
-    This wrapper function is intended to be applied to __array_ufunc__ on
-    unyt_array.
-
-    It enables subclasses of unyt_array and unyt_quantity to define two
-    classmethods: __unyt_ufunc_prepare__ and __unyt_ufunc_finalize__.
-    These are called if available to allow subclasses to prepare arguments
-    for and modify return values from numpy ufuncs.
-
-    The __unyt_ufunc_prepare__ method should be a classmethod accepting
-    (ufunc, method, *inputs, **kwargs), i.e. the same inputs as
-    __array_ufunc__. It should return
-    (prepared_ufunc, prepared_method, prepared_inputs, prepared_kwargs)
-    which correspond logically to its inputs with any modifications needed
-    by the subclass.
-
-    The __unyt_ufunc_finalize__ method should be a classmethod accepting
-    (result, ufunc, method, *inputs, **kwargs), similarly to above but with
-    the addition of result, the return value from unyt_array.__array_ufunc__.
-    It should return the result with any modifications needed by the subclass.
-    """
-
-    def wrapper(self, ufunc, method, *inputs, **kwargs):
-        if len(inputs) > 1:
-            try:
-                # check if we're dealing with types that we understand and get
-                # the return type, otherwise _get_binary_op_return_class will
-                # raise RuntimeError.
-                ret_class = _get_binary_op_return_class(
-                    type(inputs[0]), type(inputs[1])
-                )
-            except RuntimeError:
-                # we're sure none of the arguments want to modify the input
-                # or output, so bypass __unyt_ufunc_prepare__ and
-                # __unyt_ufunc_finalize__.
-                return ufunc_handler(self, ufunc, method, *inputs, **kwargs)
-        else:
-            ret_class = type(inputs[0])
-        if hasattr(ret_class, "__unyt_ufunc_prepare__"):
-            prepared_ufunc, prepared_method, prepared_inputs, prepared_kwargs = (
-                ret_class.__unyt_ufunc_prepare__(ufunc, method, *inputs, **kwargs)
-            )
-        else:
-            prepared_ufunc, prepared_method, prepared_inputs, prepared_kwargs = (
-                ufunc,
-                method,
-                inputs,
-                kwargs,
-            )
-        result = ufunc_handler(
-            self,
-            prepared_ufunc,
-            prepared_method,
-            *prepared_inputs,
-            **prepared_kwargs,
-        )
-        if hasattr(ret_class, "__unyt_ufunc_finalize__"):
-            return ret_class.__unyt_ufunc_finalize__(
-                result, ufunc, method, *inputs, **kwargs
-            )
-        else:
-            return result
-
-    return wrapper
-
-
 unary_operators = (
     negative,
     absolute,
@@ -1874,8 +1807,14 @@ class unyt_array(np.ndarray):
     # Start operation methods
     #
 
-    @_subclass_ufunc_prepare_and_finalize
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        if type(self) in (unyt_array, unyt_quantity):
+            for x in inputs:
+                if isinstance(x, unyt_array) and type(x) not in (
+                    unyt_array,
+                    unyt_quantity,
+                ):
+                    return NotImplemented
         func = getattr(ufunc, method)
         if "out" not in kwargs:
             if ufunc in multiple_output_operators:

--- a/unyt/array.py
+++ b/unyt/array.py
@@ -1867,11 +1867,16 @@ class unyt_array(np.ndarray):
                 return i1.__array_ufunc__(ufunc, method, *inputs, **kwargs)
 
             # coerce inputs to be ndarrays if they aren't already
-            inp0 = _coerce_iterable_units(i0)
-            inp1 = _coerce_iterable_units(i1)
+            try:
+                inp0 = _coerce_iterable_units(i0)
+                inp1 = _coerce_iterable_units(i1)
+            except IterableUnitCoercionError:
+                return NotImplemented
             u0 = getattr(i0, "units", None) or getattr(inp0, "units", None)
             u1 = getattr(i1, "units", None) or getattr(inp1, "units", None)
             ret_class = _get_binary_op_return_class(type(i0), type(i1))
+            if ret_class is NotImplemented:
+                return NotImplemented
             if u0 is None:
                 u0 = Unit(registry=getattr(u1, "registry", None))
             if u1 is None and ufunc is not power:
@@ -2604,10 +2609,7 @@ def _get_binary_op_return_class(cls1, cls2):
     if issubclass(cls2, cls1):
         return cls2
     else:
-        raise RuntimeError(
-            "Undefined operation for a unyt_array subclass. "
-            f"Received operand types ({cls1}) and ({cls2})"
-        )
+        return NotImplemented
 
 
 def loadtxt(fname, dtype="float", delimiter="\t", usecols=None, comments="#"):

--- a/unyt/tests/sample_subclasses.py
+++ b/unyt/tests/sample_subclasses.py
@@ -941,6 +941,8 @@ class subclass_uarray(unyt_array):
     Minimalist subclass of unyt_array.
     """
 
+    __array_priority__ = unyt_array.__array_priority__ + 10.0
+
     def __new__(
         cls,
         input_array: Iterable,
@@ -1055,41 +1057,6 @@ class subclass_uarray(unyt_array):
     T = property(_propagate_extra_attr_to_result(unyt_array.transpose))
     ua = property(_propagate_extra_attr_to_result(np.ones_like))
     unit_array = property(_propagate_extra_attr_to_result(np.ones_like))
-
-    @classmethod
-    def __unyt_ufunc_prepare__(cls, ufunc: np.ufunc, method: str, *inputs, **kwargs):
-        helper_result = _prepare_array_func_args(*inputs, **kwargs)
-        return ufunc, method, helper_result["args"], helper_result["kwargs"]
-
-    @classmethod
-    def __unyt_ufunc_finalize__(
-        cls, result, ufunc: np.ufunc, method: str, *inputs, **kwargs
-    ):
-        helper_result = _prepare_array_func_args(*inputs, **kwargs)
-        # if we get a tuple we have multiple return values to deal with
-        assert not isinstance(result, tuple)
-        if isinstance(result, unyt_array):  # also recognizes subclass_uquantity
-            if not isinstance(result, subclass_uarray):
-                result = (
-                    result.view(subclass_uquantity)
-                    if result.shape == ()
-                    else result.view(subclass_uarray)
-                )
-            result.extra_attr = helper_result["extra_attr"]
-        if "out" in kwargs:
-            out = kwargs.pop("out")
-            assert ufunc not in multiple_output_operators
-            out = out[0]
-            if isinstance(out, unyt_array) and not isinstance(out, subclass_uarray):
-                out = (
-                    out.view(subclass_uquantity)
-                    if out.shape == ()
-                    else out.view(subclass_uarray)
-                )
-            if isinstance(out, subclass_uarray):
-                # also recognizes subclass_uquantity
-                out.extra_attr = helper_result["extra_attr"]
-        return result
 
     def __array_ufunc__(
         self, ufunc: np.ufunc, method: str, *inputs, **kwargs

--- a/unyt/tests/sample_subclasses.py
+++ b/unyt/tests/sample_subclasses.py
@@ -1170,6 +1170,27 @@ class subclass_uarray(unyt_array):
         else:
             return super().__rmul__(b)
 
+    def __truediv__(
+        self, b: int | float | np.ndarray | unyt.unit_object.Unit
+    ) -> "subclass_uarray":
+        """
+        Divide this ``subclass_uarray``.
+
+        We delegate most cases to ``unyt_array``, but we need to handle
+        the case where the second argument is a ``Unit``.
+        """
+        if getattr(b, "is_Unit", False):
+            return _copy_extra_attr_if_present(
+                self,
+                _ensure_result_is_subclass_uarray_or_uquantity((1 / b).__mul__)(
+                    self.view(unyt_quantity)
+                    if self.shape == ()
+                    else self.view(unyt_array)
+                ),
+            )
+        else:
+            return super().__truediv__(b)
+
 
 class subclass_uquantity(subclass_uarray, unyt_quantity):
     """

--- a/unyt/tests/sample_subclasses.py
+++ b/unyt/tests/sample_subclasses.py
@@ -941,8 +941,6 @@ class subclass_uarray(unyt_array):
     Minimalist subclass of unyt_array.
     """
 
-    __array_priority__ = unyt_array.__array_priority__ + 10.0
-
     def __new__(
         cls,
         input_array: Iterable,

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -3049,3 +3049,58 @@ def test_squeeze_method_with_axis():
     squeeze_axis = (1,)
     arr_squeezed = arr.squeeze(axis=1)
     assert arr_squeezed.ndim == arr.ndim - len(squeeze_axis)
+
+
+def test_other_argument_can_handle_binary_ufunc():
+    class MyClass:
+        def __init__(self, x: int):
+            self.x = x
+
+        @classmethod
+        def __unyt_ufunc_prepare__(cls, ufunc, method, *inputs, **kwargs):
+            return (
+                ufunc,
+                method,
+                tuple(i.x if isinstance(i, MyClass) else i for i in inputs),
+                kwargs,
+            )
+
+        @classmethod
+        def __unyt_ufunc_finalize__(cls, result, ufunc, method, *inputs, **kwargs):
+            return result
+
+    x = 5
+    mc = MyClass(x=x)
+    uq = unyt_quantity(2, "m")
+    ua = unyt_array([2], "m")
+
+    for u in ua, uq:
+        assert_almost_equal(x * u, mc * u)
+        assert_almost_equal(x * u, u * mc)
+        assert_almost_equal(x / u, mc / u)
+        assert_almost_equal(u / x, u / mc)
+
+
+def test_other_argument_cannot_handle_binary_ufunc():
+    class MyClass:
+        def __init__(self, x: int):
+            self.x = x
+
+    x = 5
+    mc = MyClass(x=x)
+    uq = unyt_quantity(2, "m")
+    ua = unyt_array([2], "m")
+
+    msg = (
+        "Received an input or operand that cannot be converted to a "
+        "unyt_array with uniform units"
+    )
+    for u in ua, uq:
+        with pytest.raises(IterableUnitCoercionError, match=msg):
+            mc * u
+        with pytest.raises(IterableUnitCoercionError, match=msg):
+            u * mc
+        with pytest.raises(IterableUnitCoercionError, match=msg):
+            mc / u
+        with pytest.raises(IterableUnitCoercionError, match=msg):
+            u / mc

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -1519,18 +1519,18 @@ def test_subclass():
 
 def test_string_operations_raise_errors():
     a = unyt_array([1, 2, 3], "g")
-    with pytest.raises(IterableUnitCoercionError):
+    with pytest.raises(TypeError):
         a + "hello"
-    with pytest.raises(IterableUnitCoercionError):
+    with pytest.raises(TypeError):
         a * "hello"
-    with pytest.raises(IterableUnitCoercionError):
+    with pytest.raises(TypeError):
         a ** "hello"
 
 
 def test_string_ne():
     a = unyt_array([1, 2, 3], "g")
     if NUMPY_VERSION >= Version("1.25.0.dev0"):
-        ctx = pytest.raises(ValueError)
+        ctx = pytest.raises(TypeError)
     else:
         ctx = pytest.warns(FutureWarning)
     with ctx:
@@ -1539,11 +1539,11 @@ def test_string_ne():
 
 def test_string_operations_raise_errors_quantity():
     q = 2 * g
-    with pytest.raises(IterableUnitCoercionError):
+    with pytest.raises(TypeError):
         q + "hello"
-    with pytest.raises(IterableUnitCoercionError):
+    with pytest.raises(TypeError):
         q * "hello"
-    with pytest.raises(IterableUnitCoercionError):
+    with pytest.raises(TypeError):
         q ** "hello"
     assert q != "hello"
 
@@ -2303,9 +2303,9 @@ def test_coerce_iterable():
 
     assert_equal(a + b, unyt_array([2, 202, 6], "cm"))
     assert_equal(b + a, unyt_array([2, 202, 6], "cm"))
-    with pytest.raises(IterableUnitCoercionError):
+    with pytest.raises(TypeError):
         a + c
-    with pytest.raises(IterableUnitCoercionError):
+    with pytest.raises(TypeError):
         c + a
     assert_equal(unyt_array(b), unyt_array([1, 200, 3], "cm"))
     with pytest.raises(IterableUnitCoercionError):
@@ -3092,16 +3092,12 @@ def test_other_argument_cannot_handle_binary_ufunc():
     uq = unyt_quantity(2, "m")
     ua = unyt_array([2], "m")
 
-    msg = (
-        "Received an input or operand that cannot be converted to a "
-        "unyt_array with uniform units"
-    )
     for u in ua, uq:
-        with pytest.raises(IterableUnitCoercionError, match=msg):
+        with pytest.raises(TypeError):
             mc * u
-        with pytest.raises(IterableUnitCoercionError, match=msg):
+        with pytest.raises(TypeError):
             u * mc
-        with pytest.raises(IterableUnitCoercionError, match=msg):
+        with pytest.raises(TypeError):
             mc / u
-        with pytest.raises(IterableUnitCoercionError, match=msg):
+        with pytest.raises(TypeError):
             u / mc

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -1530,7 +1530,7 @@ def test_string_operations_raise_errors():
 def test_string_ne():
     a = unyt_array([1, 2, 3], "g")
     if NUMPY_VERSION >= Version("1.25.0.dev0"):
-        ctx = pytest.raises(TypeError)
+        ctx = pytest.raises(ValueError)
     else:
         ctx = pytest.warns(FutureWarning)
     with ctx:

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -3051,6 +3051,37 @@ def test_squeeze_method_with_axis():
     assert arr_squeezed.ndim == arr.ndim - len(squeeze_axis)
 
 
+def test_other_argument_can_handle_binary_ufunc():
+    class MyClass:
+        __array_ufunc__ = None
+
+        def __init__(self, x: int):
+            self.x = x
+
+        def __mul__(self, b):
+            return self.x * b
+
+        def __rmul__(self, b):
+            return self.x * b
+
+        def __truediv__(self, b):
+            return self.x / b
+
+        def __rtruediv__(self, b):
+            return b / self.x
+
+    x = 5
+    mc = MyClass(x=x)
+    uq = unyt_quantity(2, "m")
+    ua = unyt_array([2], "m")
+
+    for u in ua, uq:
+        assert_almost_equal(x * u, mc * u)
+        assert_almost_equal(x * u, u * mc)
+        assert_almost_equal(x / u, mc / u)
+        assert_almost_equal(u / x, u / mc)
+
+
 def test_other_argument_cannot_handle_binary_ufunc():
     class MyClass:
         def __init__(self, x: int):

--- a/unyt/tests/test_unyt_array.py
+++ b/unyt/tests/test_unyt_array.py
@@ -3051,36 +3051,6 @@ def test_squeeze_method_with_axis():
     assert arr_squeezed.ndim == arr.ndim - len(squeeze_axis)
 
 
-def test_other_argument_can_handle_binary_ufunc():
-    class MyClass:
-        def __init__(self, x: int):
-            self.x = x
-
-        @classmethod
-        def __unyt_ufunc_prepare__(cls, ufunc, method, *inputs, **kwargs):
-            return (
-                ufunc,
-                method,
-                tuple(i.x if isinstance(i, MyClass) else i for i in inputs),
-                kwargs,
-            )
-
-        @classmethod
-        def __unyt_ufunc_finalize__(cls, result, ufunc, method, *inputs, **kwargs):
-            return result
-
-    x = 5
-    mc = MyClass(x=x)
-    uq = unyt_quantity(2, "m")
-    ua = unyt_array([2], "m")
-
-    for u in ua, uq:
-        assert_almost_equal(x * u, mc * u)
-        assert_almost_equal(x * u, u * mc)
-        assert_almost_equal(x / u, mc / u)
-        assert_almost_equal(u / x, u / mc)
-
-
 def test_other_argument_cannot_handle_binary_ufunc():
     class MyClass:
         def __init__(self, x: int):


### PR DESCRIPTION
Following some further research and tinkering, this is a second attempt at #641 that is a *much* simpler implementation. It removes a lot of logic that subclasses previously had to hook into, instead `unyt_array.__array_ufunc__` now returns `NotImplemented` when it is confronted with (1) input that it cannot understand, or (2) a subclass (except `unyt_quantity`). This allows both subclasses and other classes to have a chance to decide how the operation should be resolved before unyt unilaterally raises an exception. The previous tests still pass, and I've added a new one illustrating how a class that is not a subclass can make use of `NotImplemented` being returned to implement right-sided multiplication and division.